### PR TITLE
prevent NullPointerException if znode contains no data. TODO comment …

### DIFF
--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySource.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySource.java
@@ -42,6 +42,11 @@ public class ZookeeperPropertySource extends EnumerablePropertySource<CuratorFra
 			cache = TreeCache.newBuilder(source, context).build();
 			cache.start();
 			running = true;
+            /*
+                TODO: race condition since TreeCache.process(..) is invoked asynchronously.
+                Methods getProperty and getPropertyNames could be invoked before that TreeCache.process(..) receives
+                all the WatchedEvents.
+            */
 		}
 		catch (NoNodeException e) {
 			// no node, ignore
@@ -74,7 +79,7 @@ public class ZookeeperPropertySource extends EnumerablePropertySource<CuratorFra
 			return;
 		for (Map.Entry<String, ChildData> entry : children.entrySet()) {
 			ChildData child = entry.getValue();
-			if (child.getData().length == 0) {
+			if (child.getData()==null || child.getData().length == 0) {
 				findKeys(keys, child.getPath());
 			}
 			else {


### PR DESCRIPTION
If a znode contains no data, the method findKeys throws NullPoninteException.

I have created an empty znode with zkCli 3.5.0 ( zookeeper command line )

       create /myemptyznode


I also have included a comment about a possible race condition. The TreeCache.process(..) method  is asynchronous and therefore the TreeCache.start() method doesn't wait for all the entries are loaded.