### PR TITLE
Further 4financeIT migration

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
@@ -1,15 +1,10 @@
 package org.springframework.cloud.zookeeper.discovery;
 
 import lombok.SneakyThrows;
-import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -73,7 +68,8 @@ public class ZookeeperDiscoveryClient implements DiscoveryClient {
 
 	private String getServiceIdToQuery(String serviceId) {
 		if (zookeeperDependencies != null && zookeeperDependencies.hasDependencies()) {
-			return zookeeperDependencies.getPathForAlias(serviceId);
+			String pathForAlias = zookeeperDependencies.getPathForAlias(serviceId);
+			return pathForAlias.isEmpty() ? serviceId : pathForAlias;
 		}
 		return serviceId;
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
@@ -5,6 +5,7 @@ import org.apache.curator.x.discovery.details.InstanceSerializer;
 import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Spencer Gibb
  */
 @Configuration
+@ConditionalOnProperty(value = "zookeeper.discovery.enabled", matchIfMissing = true)
 @EnableConfigurationProperties
 public class ZookeeperDiscoveryClientConfiguration {
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
@@ -4,6 +4,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.details.InstanceSerializer;
 import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ public class ZookeeperDiscoveryClientConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	public ZookeeperServiceDiscovery zookeeperServiceDiscovery() {
 		return new ZookeeperServiceDiscovery(curator, zookeeperDiscoveryProperties(),
 				instanceSerializer());

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
@@ -16,10 +16,5 @@ public class ZookeeperDiscoveryProperties {
 
 	private String uriSpec = "{scheme}://{address}:{port}";
 
-	/**
-	 * @param realm allows you to register a service under specified realm
-	 */
-	private String realm;
-
 	private String instanceHost;
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -75,10 +75,28 @@ public class ZookeeperDependencies {
 		return !dependencies.isEmpty();
 	}
 
+	public ZookeeperDependency getDependencyForAlias(final String alias) {
+		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
+			if (zookeeperDependencyEntry.getKey().equals(alias)) {
+				return zookeeperDependencyEntry.getValue();
+			}
+		}
+		return null;
+	}
+
 	public String getPathForAlias(final String alias) {
 		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
 			if (zookeeperDependencyEntry.getKey().equals(alias)) {
 				return zookeeperDependencyEntry.getValue().getPath();
+			}
+		}
+		return "";
+	}
+
+	public String getAliasForPath(final String path) {
+		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
+			if (zookeeperDependencyEntry.getValue().getPath().equals(path)) {
+				return zookeeperDependencyEntry.getKey();
 			}
 		}
 		return "";

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryWithDependenciesISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryWithDependenciesISpec.groovy
@@ -50,6 +50,11 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification {
 		wireMock.register(get(urlEqualTo('/ping')).willReturn(aResponse().withBody('pong')))
 	}
 
+	def 'should find an instance via path when alias is not found'() {
+		expect:
+			!discoveryClient.getInstances('some/name/without/alias').empty
+	}
+
 	def 'should find a collaborator via Ribbon by using its alias from dependencies'() {
 		expect:
 			'pong' == testRibbonClient.pingService('someAlias')

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-watcher.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-watcher.yml
@@ -1,4 +1,4 @@
-spring.application.name: someName
+spring.application.name: some/name/without/alias
 zookeeper:
   dependencies:
     someAlias:


### PR DESCRIPTION
Some additional changes that are required for the dependency mechanism to work.

Conditional on props
================

```
@ConditionalOnProperty(value = "zookeeper.enabled", matchIfMissing = true)
public class ZookeeperAutoConfiguration {...}

@ConditionalOnProperty(value = "zookeeper.discovery.enabled", matchIfMissing = true)
public class ZookeeperDiscoveryClientConfiguration {...}
```
Required if you want to perform a gradual roll out of the Spring Cloud Zookeeper approach. For example in our case we want by default to have it disabled but for a profile we want to have it enabled. Check this out for more info: https://github.com/4finance/boot-microservice/blob/tech/spring-cloud-zookeeper-migration/src/main/resources/bootstrap-springCloud.yaml

Bean in creation
================

```
@Bean(destroyMethod = "close")
@ConditionalOnMissingBean	
public CuratorFramework curatorFramework(RetryPolicy retryPolicy) {...}
```

Added destroy method and `RetryPolicy` as an argument of the method. Removed `private @Autowired RetryPolicy retryPolicy;`. 
Without those changes I had circular dependencies. We have our own `CuratorFramework` bean that also requires `RetryPolicy`. That `RetryPolicy` was required by this configuration to be injected to the autowire field. At the same time the `RetryPolicy` was created in our configuration - Spring shouted that it can't inject the bean to your config when it's being created in ours. This change saved the day :)

ServiceID resolution
================

```
String pathForAlias = zookeeperDependencies.getPathForAlias(serviceId);
return pathForAlias.isEmpty() ? serviceId : pathForAlias;
```

When building the graph of microservices we're querying not necessarily by aliases but by paths (so in fact serviceID). In the first approach I always assumed that serviceId will be an alias (which is the case via Ribbon). 
The solution is to try to treat serviceId as an alias and if that's not the case I'm assuming that it's actually not the alias but the path.

Conditional on missing bean
================
```
@ConditionalOnMissingBean
public ZookeeperServiceDiscovery zookeeperServiceDiscovery() { ... }
```

We have our own `ZookeeperServiceDiscovery` implementation so this one should be set only if bean is missing.

Redundant realm
================

```
-	private String realm;
```

Realm is nothing else but a base path so it's redundant.

Helper functions
================

```
public ZookeeperDependency getDependencyForAlias(final String alias) {
		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
			if (zookeeperDependencyEntry.getKey().equals(alias)) {
				return zookeeperDependencyEntry.getValue();
			}
		}
		return null;
}

	public String getAliasForPath(final String path) {
		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
			if (zookeeperDependencyEntry.getValue().getPath().equals(path)) {
				return zookeeperDependencyEntry.getKey();
			}
		}
		return "";
	}
```

Some helper functions. Nothing special.

Possibility to configure ServiceInstance and ServiceDiscovery
==================

```
@SneakyThrows
	public void build() {
		if (built.compareAndSet(false, true)) {
			if (port.get() <= 0) {
				throw new IllegalStateException("Cannot create instance whose port is not greater than 0");
			}
			String host = properties.getInstanceHost() == null? getIpAddress() : properties.getInstanceHost();
			UriSpec uriSpec = new UriSpec(properties.getUriSpec());
			configureServiceInstance(serviceInstance, appName, context, port, host, uriSpec);
			configureServiceDiscovery(serviceDiscovery, curator, properties, instanceSerializer, serviceInstance);
		}
	}

	@SneakyThrows
	protected void configureServiceInstance(AtomicReference<ServiceInstance<ZookeeperInstance>> serviceInstance,
											String appName,
											ApplicationContext context,
											AtomicInteger port,
											String host,
											UriSpec uriSpec) {
		// @formatter:off
		serviceInstance.set(ServiceInstance.<ZookeeperInstance>builder()
				.name(appName)
				.payload(new ZookeeperInstance(context.getId()))
				.port(port.get())
				.address(host)
				.uriSpec(uriSpec).build());
		// @formatter:on
	}

	@SneakyThrows
	protected void configureServiceDiscovery(AtomicReference<ServiceDiscovery<ZookeeperInstance>> serviceDiscovery,
											 CuratorFramework curator,
											 ZookeeperDiscoveryProperties properties,
											 InstanceSerializer<ZookeeperInstance> instanceSerializer,
											 AtomicReference<ServiceInstance<ZookeeperInstance>> serviceInstance) {
		// @formatter:off
		serviceDiscovery.set(ServiceDiscoveryBuilder.builder(ZookeeperInstance.class)
				.client(curator)
				.basePath(properties.getRoot())
				.serializer(instanceSerializer)
				.thisInstance(serviceInstance.get())
				.build());
		// @formatter:on
	}
```

I don't know if I've done it in a nice way but I didn't sleep much today (I don't like the number of params) ;) In 4financeIT we don't support `ServiceInstance` that has a payload. If we provide that payload the production will burn ;)

That's why it would be cool to make it possible to do further additional configuration:

```
ZookeeperServiceDiscovery zookeeperServiceDiscovery = new ZookeeperServiceDiscovery(curator, zookeeperDiscoveryProperties, instanceSerializer) {
            @Override
            protected void configureServiceInstance(AtomicReference<ServiceInstance<ZookeeperInstance>> serviceInstance, String appName, ApplicationContext context, AtomicInteger port, String host, UriSpec uriSpec) {
                try {
                    serviceInstance.set(ServiceInstance.<ZookeeperInstance>builder()
                            .name(appName)
                            .port(port.get())
                            .address(host)
                            .uriSpec(uriSpec).build());
                } catch (Exception e) {
                    LOG.error("Exception occurred while trying to build ServiceInstance", e);
                    throw new RuntimeException(e);
                }
            }
        };
```

@spencergibb WDYT?