### PR TITLE
Tech/wip on loadbalancer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
 - mvn --settings .settings.xml install -P docs -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
 - ./docs/src/main/asciidoc/ghpages.sh
 script:
-- mvn dependency:tree -s .settings.xml
 - '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || mvn --settings .settings.xml deploy -nsu'
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] || mvn --settings .settings.xml install -nsu'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 - mvn --settings .settings.xml install -P docs -q -U -DskipTests=true -Dmaven.test.redirectTestOutputToFile=true
 - ./docs/src/main/asciidoc/ghpages.sh
 script:
+- mvn dependency:tree -s .settings.xml
 - '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || mvn --settings .settings.xml deploy -nsu'
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] || mvn --settings .settings.xml install -nsu'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+sudo: false
+
+cache:
+  directories:
+  - $HOME/.gradle
+  - $HOME/.m2
+
 language: java
 before_install:
   - git config user.name "$GIT_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 
 cache:
   directories:
-  - $HOME/.gradle
   - $HOME/.m2
 
 language: java

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 			<dependency>
 				<groupId>org.codehaus.groovy</groupId>
 				<artifactId>groovy-all</artifactId>
-				<version>2.4.3</version>
+				<version>2.4.4</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperConfigBootstrapConfiguration.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperConfigBootstrapConfiguration.java
@@ -1,4 +1,4 @@
-package org.springframework.cloud.zookeeper.config;
+package org.springframework.cloud.zookeeper.common;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperConfigProperties.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperConfigProperties.java
@@ -1,4 +1,4 @@
-package org.springframework.cloud.zookeeper.config;
+package org.springframework.cloud.zookeeper.common;
 
 import lombok.Data;
 

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperPropertySource.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperPropertySource.java
@@ -1,4 +1,4 @@
-package org.springframework.cloud.zookeeper.config;
+package org.springframework.cloud.zookeeper.common;
 
 import java.nio.charset.Charset;
 import java.util.ArrayList;

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperPropertySourceLocator.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/common/ZookeeperPropertySourceLocator.java
@@ -1,4 +1,4 @@
-package org.springframework.cloud.zookeeper.config;
+package org.springframework.cloud.zookeeper.common;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.zookeeper.discovery;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@ConditionalOnProperty(value = "ribbon.zookeeper.enabled", matchIfMissing = true)
+public @interface ConditionalOnRibbonZookeeper {
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
@@ -7,6 +7,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Wrapper annotation to enable Ribbon for Zookeeper
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @ConditionalOnProperty(value = "ribbon.zookeeper.enabled", matchIfMissing = true)

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/RibbonZookeeperAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/RibbonZookeeperAutoConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.cloud.zookeeper.discovery;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
@@ -31,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties
 @ConditionalOnBean(SpringClientFactory.class)
-@ConditionalOnProperty(value = "ribbon.zookeeper.enabled", matchIfMissing = true)
+@ConditionalOnRibbonZookeeper
 @AutoConfigureAfter(RibbonAutoConfiguration.class)
 @RibbonClients(defaultConfiguration = ZookeeperRibbonClientConfiguration.class)
 public class RibbonZookeeperAutoConfiguration {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesPassed.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesPassed.java
@@ -1,0 +1,21 @@
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to turn on a feature if Zookeeper dependencies have been passed
+ *
+ * @author Marcin Grzejszczak, 4financeIT
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(DependenciesPassedCondition.class)
+@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.enabled", matchIfMissing = true)
+public @interface ConditionalOnDependenciesPassed {
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
@@ -1,0 +1,59 @@
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import com.netflix.loadbalancer.*;
+
+/**
+ * LoadBalancer that delegates to other rules depending on the provided load balancing strategy
+ * in the {@link ZookeeperDependencies.ZookeeperDependency#getLoadBalancerType()}
+ *
+ * @author Marcin Grzejszczak, 4financeIT
+ */
+public class DependenciesBasedLoadBalancer extends BaseLoadBalancer {
+
+	private final ZookeeperDependencies zookeeperDependencies;
+
+	public DependenciesBasedLoadBalancer(ZookeeperDependencies zookeeperDependencies, ServerList serverList) {
+		this.zookeeperDependencies = zookeeperDependencies;
+		setServersList(serverList.getInitialListOfServers());
+	}
+
+	@Override
+	public Server chooseServer(Object key) {
+		String keyAsString = (String) key;
+		ZookeeperDependencies.ZookeeperDependency dependency = zookeeperDependencies.getDependencyForAlias(keyAsString);
+		if (dependency == null) {
+			return rule.choose(key);
+		} ;
+		IRule loadBalancerRule = chooseRuleForLoadBalancerType(dependency.getLoadBalancerType());
+		return loadBalancerRule.choose(key);
+	}
+
+	private IRule chooseRuleForLoadBalancerType(LoadBalancerType type) {
+		switch (type) {
+			case ROUND_ROBIN:
+				return getRoundRobinRule();
+			case RANDOM:
+				return getRandomRule();
+			case STICKY:
+				return getStickyRule();
+			default:
+				throw new IllegalArgumentException("Unknown load balancer type " + type);
+		}
+	}
+
+	private RoundRobinRule getRoundRobinRule() {
+		return new RoundRobinRule(this);
+	}
+
+	private IRule getRandomRule() {
+		RandomRule randomRule = new RandomRule();
+		randomRule.setLoadBalancer(this);
+		return randomRule;
+	}
+
+	private IRule getStickyRule() {
+		StickyRule stickyRule = new StickyRule(getRoundRobinRule());
+		stickyRule.setLoadBalancer(this);
+		return stickyRule;
+	}
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class DependenciesBasedLoadBalancer extends BaseLoadBalancer {
 
-	private static final Map<String, IRule> RULE_CACHE = new ConcurrentHashMap<>();
+	private final Map<String, IRule> ruleCache = new ConcurrentHashMap<>();
 
 	private final ZookeeperDependencies zookeeperDependencies;
 
@@ -29,10 +29,14 @@ public class DependenciesBasedLoadBalancer extends BaseLoadBalancer {
 		if (dependency == null) {
 			return rule.choose(key);
 		};
-		if (!RULE_CACHE.containsKey(keyAsString)) {
-			RULE_CACHE.put(keyAsString, chooseRuleForLoadBalancerType(dependency.getLoadBalancerType()));
+		cacheEntryIfMissing(keyAsString, dependency);
+		return ruleCache.get(keyAsString).choose(key);
+	}
+
+	private void cacheEntryIfMissing(String keyAsString, ZookeeperDependencies.ZookeeperDependency dependency) {
+		if (!ruleCache.containsKey(keyAsString)) {
+			ruleCache.put(keyAsString, chooseRuleForLoadBalancerType(dependency.getLoadBalancerType()));
 		}
-		return RULE_CACHE.get(keyAsString).choose(key);
 	}
 
 	private IRule chooseRuleForLoadBalancerType(LoadBalancerType type) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
@@ -38,6 +39,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(RibbonAutoConfiguration.class)
 @ConditionalOnRibbonZookeeper
 @Configuration
+@Slf4j
 public class DependencyRibbonAutoConfiguration {
 
 	@Bean
@@ -52,7 +54,9 @@ public class DependencyRibbonAutoConfiguration {
 			}
 
 			private Server chooseServerByServiceIdOrDefault(ILoadBalancer loadBalancer, String serviceId) {
+				log.debug("Dependencies are set - will try to load balance via provided load balancer [{}] for key [{}]", loadBalancer, serviceId);
 				Server server = loadBalancer.chooseServer(serviceId);
+				log.debug("Retrieved server [{}] via load balancer", server);
 				return server != null ? server : loadBalancer.chooseServer("default");
 			}
 		};

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(RibbonAutoConfiguration.class)
 @ConditionalOnRibbonZookeeper
 @Configuration
-public class ZookeeperDependencyRibbonLoadBalancerClientConfiguration {
+public class DependencyRibbonAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
@@ -1,0 +1,58 @@
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import com.netflix.client.config.IClientConfig;
+import com.netflix.loadbalancer.AbstractLoadBalancerRule;
+import com.netflix.loadbalancer.IRule;
+import com.netflix.loadbalancer.Server;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Ported from {@link org.apache.curator.x.discovery.strategies.StickyStrategy}
+ *
+ * author: Marcin Grzejszczak, 4financeIT
+ */
+public class StickyRule extends AbstractLoadBalancerRule {
+	private final IRule masterStrategy;
+	private final AtomicReference<Server> ourInstance = new AtomicReference<>(null);
+	private final AtomicInteger instanceNumber = new AtomicInteger(-1);
+
+	public StickyRule(IRule masterStrategy) {
+		this.masterStrategy = masterStrategy;
+	}
+
+	@Override
+	public void initWithNiwsConfig(IClientConfig iClientConfig) {
+
+	}
+
+	@Override
+	public Server choose(Object key) {
+		final List<Server> instances = getLoadBalancer().getServerList(true);
+		Server localOurInstance = ourInstance.get();
+		if (!instances.contains(localOurInstance)) {
+			ourInstance.compareAndSet(localOurInstance, null);
+		}
+		if (ourInstance.get() == null) {
+			Server instance = masterStrategy.choose(key);
+			if (ourInstance.compareAndSet(null, instance)) {
+				instanceNumber.incrementAndGet();
+			}
+		}
+		return ourInstance.get();
+	}
+
+	/**
+	 * Each time a new instance is picked, an internal counter is incremented. This way you
+	 * can track when/if the instance changes. The instance can change when the selected instance
+	 * is not in the current list of instances returned by the instance provider
+	 *
+	 * @return instance number
+	 */
+	public int getInstanceNumber() {
+		return instanceNumber.get();
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
@@ -4,6 +4,7 @@ import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.AbstractLoadBalancerRule;
 import com.netflix.loadbalancer.IRule;
 import com.netflix.loadbalancer.Server;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -16,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * author: Marcin Grzejszczak, 4financeIT
  */
+@Slf4j
 public class StickyRule extends AbstractLoadBalancerRule {
 	private final IRule masterStrategy;
 	private final AtomicReference<Server> ourInstance = new AtomicReference<>(null);
@@ -33,7 +35,9 @@ public class StickyRule extends AbstractLoadBalancerRule {
 	@Override
 	public Server choose(Object key) {
 		final List<Server> instances = getLoadBalancer().getServerList(true);
+		log.debug("Instances taken from load balancer {}", instances);
 		Server localOurInstance = ourInstance.get();
+		log.debug("Current saved instance [{}]", localOurInstance);
 		if (!instances.contains(localOurInstance)) {
 			ourInstance.compareAndSet(localOurInstance, null);
 		}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
@@ -10,6 +10,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * Load balancing rule that returns always the same instance.
+ *
  * Ported from {@link org.apache.curator.x.discovery.strategies.StickyStrategy}
  *
  * author: Marcin Grzejszczak, 4financeIT

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -75,7 +75,7 @@ public class ZookeeperDependencies {
 		return !dependencies.isEmpty();
 	}
 
-	public ZookeeperDependency getDependencyForPath(String path) {
+	public ZookeeperDependency getDependencyForPath(final String path) {
 		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
 			if (zookeeperDependencyEntry.getValue().getPath().equals(path)) {
 				return zookeeperDependencyEntry.getValue();

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -67,6 +67,7 @@ public class ZookeeperDependencies {
 		private boolean required;
 
 	}
+
 	public Collection<ZookeeperDependency> getDependencyConfigurations() {
 		return dependencies.values();
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -56,7 +56,7 @@ public class ZookeeperDependencies {
 
 		private String path;
 
-		private LoadBalancerType loadBalancerType;
+		private LoadBalancerType loadBalancerType = LoadBalancerType.ROUND_ROBIN;
 
 		private String contentTypeTemplate;
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -65,14 +65,23 @@ public class ZookeeperDependencies {
 		private Map<String, String> headers;
 
 		private boolean required;
-	}
 
+	}
 	public Collection<ZookeeperDependency> getDependencyConfigurations() {
 		return dependencies.values();
 	}
 
 	public boolean hasDependencies() {
 		return !dependencies.isEmpty();
+	}
+
+	public ZookeeperDependency getDependencyForPath(String path) {
+		for (Map.Entry<String, ZookeeperDependency> zookeeperDependencyEntry : dependencies.entrySet()) {
+			if (zookeeperDependencyEntry.getValue().getPath().equals(path)) {
+				return zookeeperDependencyEntry.getValue();
+			}
+		}
+		return null;
 	}
 
 	public ZookeeperDependency getDependencyForAlias(final String alias) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesAutoConfiguration.java
@@ -17,11 +17,9 @@ package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -34,8 +32,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties
-@Conditional(DependenciesPassedCondition.class)
-@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.enabled", matchIfMissing = true)
+@ConditionalOnDependenciesPassed
 @AutoConfigureAfter(ZookeeperAutoConfiguration.class)
 public class ZookeeperDependenciesAutoConfiguration {
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencyRibbonLoadBalancerClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencyRibbonLoadBalancerClientConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *			http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.Server;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
+import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.cloud.zookeeper.discovery.ConditionalOnRibbonZookeeper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Marcin Grzejszczak, 4financeIT
+ */
+@AutoConfigureBefore(RibbonAutoConfiguration.class)
+@ConditionalOnRibbonZookeeper
+@Configuration
+public class ZookeeperDependencyRibbonLoadBalancerClientConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnDependenciesPassed
+	public LoadBalancerClient loadBalancerClient(SpringClientFactory springClientFactory) {
+		return new RibbonLoadBalancerClient(springClientFactory) {
+			@Override
+			protected Server getServer(String serviceId) {
+				ILoadBalancer loadBalancer = this.getLoadBalancer(serviceId);
+				return loadBalancer == null ? null : chooseServerByServiceIdOrDefault(loadBalancer, serviceId);
+			}
+
+			private Server chooseServerByServiceIdOrDefault(ILoadBalancer loadBalancer, String serviceId) {
+				Server server = loadBalancer.chooseServer(serviceId);
+				return server != null ? server : loadBalancer.chooseServer("default");
+			}
+		};
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencyRibbonLoadBalancerClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencyRibbonLoadBalancerClientConfiguration.java
@@ -29,6 +29,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
+ *
+ * Provides LoadBalancerClient that at runtime can pick proper load balancing strategy
+ * basing on the Zookeeper dependencies from properties
+ *
  * @author Marcin Grzejszczak, 4financeIT
  */
 @AutoConfigureBefore(RibbonAutoConfiguration.class)

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherAutoConfiguration.java
@@ -15,23 +15,21 @@
  */
 package org.springframework.cloud.zookeeper.discovery.watcher;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperServiceDiscovery;
-import org.springframework.cloud.zookeeper.discovery.dependency.DependenciesPassedCondition;
+import org.springframework.cloud.zookeeper.discovery.dependency.ConditionalOnDependenciesPassed;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependenciesAutoConfiguration;
 import org.springframework.cloud.zookeeper.discovery.watcher.presence.DefaultDependencyPresenceOnStartupVerifier;
 import org.springframework.cloud.zookeeper.discovery.watcher.presence.DependencyPresenceOnStartupVerifier;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Provides hooks for observing dependency lifecycle in Zookeeper.
@@ -43,8 +41,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @EnableConfigurationProperties
-@Conditional(DependenciesPassedCondition.class)
-@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.enabled", matchIfMissing = true)
+@ConditionalOnDependenciesPassed
 @AutoConfigureAfter(ZookeeperDependenciesAutoConfiguration.class)
 public class DependencyWatcherAutoConfiguration {
 

--- a/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,6 @@
 # Auto Configuration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencyRibbonLoadBalancerClientConfiguration,\
 org.springframework.cloud.zookeeper.discovery.RibbonZookeeperAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependenciesAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.watcher.DependencyWatcherAutoConfiguration

--- a/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,6 @@
 # Auto Configuration
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencyRibbonLoadBalancerClientConfiguration,\
+org.springframework.cloud.zookeeper.discovery.dependency.DependencyRibbonAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.RibbonZookeeperAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependenciesAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.watcher.DependencyWatcherAutoConfiguration

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/CommonTestConfig.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/CommonTestConfig.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.zookeeper.config
+package org.springframework.cloud.zookeeper.common
 
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/TestRibbonClient.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/TestRibbonClient.groovy
@@ -1,0 +1,23 @@
+package org.springframework.cloud.zookeeper.common
+
+import org.springframework.web.client.RestTemplate
+
+class TestRibbonClient extends TestServiceRestClient {
+
+    private final String thisAppName
+
+    TestRibbonClient(RestTemplate restTemplate) {
+        super(restTemplate)
+        this.thisAppName = 'someName'
+    }
+
+    TestRibbonClient(RestTemplate restTemplate, String thisAppName) {
+        super(restTemplate)
+        this.thisAppName = thisAppName
+    }
+
+    String thisHealthCheck() {
+        return restTemplate.getForObject("http://$thisAppName/health", String)
+    }
+
+}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/TestServiceRestClient.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/common/TestServiceRestClient.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.zookeeper.discovery
+package org.springframework.cloud.zookeeper.common
 
 import groovy.transform.CompileStatic
 import org.springframework.web.client.RestTemplate

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/config/CommonTestConfig.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/config/CommonTestConfig.groovy
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.zookeeper.discovery
+package org.springframework.cloud.zookeeper.config
 
-import com.github.tomakehurst.wiremock.WireMockServer
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
-import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.test.TestingServer
 import org.springframework.cloud.zookeeper.ZookeeperProperties
 import org.springframework.context.annotation.Bean
@@ -32,15 +30,6 @@ class CommonTestConfig {
 	@Bean(destroyMethod = 'close')
 	TestingServer testingServer() {
 		return new TestingServer(SocketUtils.findAvailableTcpPort())
-	}
-
-	@Bean(initMethod = "start", destroyMethod = "stop")
-	TestServiceRegistrar testServiceRegistrar(CuratorFramework curatorFramework) {
-		return new TestServiceRegistrar(wiremockServer().port(), curatorFramework)
-	}
-
-	@Bean(initMethod = "start", destroyMethod = "shutdown") WireMockServer wiremockServer() {
-		return new WireMockServer(SocketUtils.findAvailableTcpPort())
 	}
 
 	@Bean ZookeeperProperties zookeeperProperties() {

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRegistrar.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRegistrar.groovy
@@ -25,12 +25,12 @@ import org.apache.curator.x.discovery.UriSpec
 @CompileStatic
 class TestServiceRegistrar {
 
-	private final int wiremockServerPort
+	private final int serverPort
 	private final CuratorFramework curatorFramework
 	private final ServiceDiscovery serviceDiscovery
 
-	TestServiceRegistrar(int wiremockServerPort, CuratorFramework curatorFramework) {
-		this.wiremockServerPort = wiremockServerPort
+	TestServiceRegistrar(int serverPort, CuratorFramework curatorFramework) {
+		this.serverPort = serverPort
 		this.curatorFramework = curatorFramework
 		this.serviceDiscovery = serviceDiscovery()
 	}
@@ -42,7 +42,7 @@ class TestServiceRegistrar {
 	ServiceInstance serviceInstance() {
 		return ServiceInstance.builder().uriSpec(new UriSpec("{scheme}://{address}:{port}/"))
 				.address('localhost')
-				.port(wiremockServerPort)
+				.port(serverPort)
 				.name('testInstance')
 				.build()
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRestClient.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRestClient.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.springframework.cloud.zookeeper.discovery
+
 import groovy.transform.CompileStatic
 import org.springframework.web.client.RestTemplate
 
@@ -26,15 +27,11 @@ class TestServiceRestClient {
 		this.restTemplate = restTemplate
 	}
 
-	String pingService(String alias) {
-		return callService(alias, 'ping')
+	String callService(String alias, String endpoint) {
+		return restTemplate.getForObject("http://$alias/$endpoint", String)
 	}
 
-	String callService(String alias, String url) {
-		return restTemplate.getForObject("http://$alias/$url", String)
-	}
-
-	String pingOnUrl(String url) {
-		return new RestTemplate().getForObject("http://$url/ping", String)
+	String callOnUrl(String url, String endpoint) {
+		return new RestTemplate().getForObject("http://$url/$endpoint", String)
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRestClient.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/TestServiceRestClient.groovy
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 package org.springframework.cloud.zookeeper.discovery
-
-import groovy.transform.PackageScope
 import groovy.transform.CompileStatic
 import org.springframework.web.client.RestTemplate
 
-@PackageScope
 @CompileStatic
 class TestServiceRestClient {
 
@@ -30,7 +27,11 @@ class TestServiceRestClient {
 	}
 
 	String pingService(String alias) {
-		return restTemplate.getForObject("http://$alias/ping", String)
+		return callService(alias, 'ping')
+	}
+
+	String callService(String alias, String url) {
+		return restTemplate.getForObject("http://$alias/$url", String)
 	}
 
 	String pingOnUrl(String url) {

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryISpec.groovy
@@ -25,7 +25,8 @@ import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.client.discovery.DiscoveryClient
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
-import org.springframework.cloud.zookeeper.config.CommonTestConfig
+import org.springframework.cloud.zookeeper.common.CommonTestConfig
+import org.springframework.cloud.zookeeper.common.TestRibbonClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -84,21 +85,5 @@ class ZookeeperDiscoveryISpec extends Specification {
 										  @Value('${spring.application.name}') String springAppName) {
 			return new TestRibbonClient(restTemplate, springAppName)
 		}
-
-	}
-
-	static class TestRibbonClient extends TestServiceRestClient {
-
-		private final String thisAppName
-
-		TestRibbonClient(RestTemplate restTemplate, String thisAppName) {
-			super(restTemplate)
-			this.thisAppName = thisAppName
-		}
-
-		String thisHealthCheck() {
-			return restTemplate.getForObject("http://$thisAppName/health", String)
-		}
-
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryISpec.groovy
@@ -15,8 +15,6 @@
  */
 package org.springframework.cloud.zookeeper.discovery
 
-import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock
 import groovy.json.JsonSlurper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -27,53 +25,46 @@ import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.client.discovery.DiscoveryClient
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
+import org.springframework.cloud.zookeeper.config.CommonTestConfig
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*
 
 @ContextConfiguration(classes = Config, loader = SpringApplicationContextLoader)
 @ActiveProfiles('ribbon')
 @WebIntegrationTest(randomPort = true)
 class ZookeeperDiscoveryISpec extends Specification {
 
-	public static final String TEST_INSTANCE_NAME = 'testInstance'
-
 	@Autowired TestRibbonClient testRibbonClient
-	@Autowired WireMockServer wiremockServer
 	@Autowired DiscoveryClient discoveryClient
     @Autowired ZookeeperServiceDiscovery serviceDiscovery
-	WireMock wireMock
+	@Value('${spring.application.name}') String springAppName
 
-	def setup() {
-		wireMock = new WireMock('localhost', wiremockServer.port())
-		wireMock.register(get(urlEqualTo('/ping')).willReturn(aResponse().withBody('pong')))
-	}
-
-	def 'should find a collaborator via Ribbon'() {
-		expect:
-			'pong' == testRibbonClient.pingService(TEST_INSTANCE_NAME)
-	}
 
 	def 'should find the app by its name via Ribbon'() {
-		given:
-            def jsonSlurper = new JsonSlurper()
-            def health = jsonSlurper.parseText(testRibbonClient.thisHealthCheck())
 		expect:
-			'UP' == health.status
+			'UP' == registeredServiceStatusViaServiceName()
 	}
 
 	def 'should find a collaborator via discovery client'() {
 		given:
-			List<ServiceInstance> instances = discoveryClient.getInstances(TEST_INSTANCE_NAME)
+			List<ServiceInstance> instances = discoveryClient.getInstances(springAppName)
 			ServiceInstance instance = instances.first()
 		expect:
-			'pong' == testRibbonClient.pingOnUrl("${instance.host}:${instance.port}")
+			'UP' == registeredServiceStatus(instance)
+	}
+
+	private String registeredServiceStatusViaServiceName() {
+		return new JsonSlurper().parseText(testRibbonClient.thisHealthCheck()).status
+	}
+
+	private String registeredServiceStatus(ServiceInstance instance) {
+		return new JsonSlurper().parseText(testRibbonClient.callOnUrl("${instance.host}:${instance.port}", 'health')).status
 	}
 
 	def 'should properly find local instance'() {
@@ -85,6 +76,7 @@ class ZookeeperDiscoveryISpec extends Specification {
 	@EnableAutoConfiguration
 	@Import(CommonTestConfig)
 	@EnableDiscoveryClient
+	@Profile('ribbon')
 	static class Config {
 
 		@Bean

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.zookeeper.discovery.dependency
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.test.TestingServer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.boot.test.WebIntegrationTest
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient
+import org.springframework.cloud.client.loadbalancer.LoadBalanced
+import org.springframework.cloud.zookeeper.ZookeeperProperties
+import org.springframework.cloud.zookeeper.discovery.TestServiceRegistrar
+import org.springframework.cloud.zookeeper.discovery.TestServiceRestClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.util.SocketUtils
+import org.springframework.web.client.RestTemplate
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+@ContextConfiguration(classes = Config, loader = SpringApplicationContextLoader)
+@ActiveProfiles('loadbalancerclient')
+@WebIntegrationTest(randomPort = true)
+class StickyRuleISpec extends Specification {
+
+	@Autowired TestRibbonClient testRibbonClient
+	@Autowired WireMockServer wiremockServerOne
+	@Autowired WireMockServer wiremockServerTwo
+
+	def setup() {
+		new WireMock('localhost', wiremockServerOne.port()).register(get(urlEqualTo('/ping')).willReturn(aResponse().withBody('pong')))
+		new WireMock('localhost', wiremockServerTwo.port()).register(get(urlEqualTo('/ping')).willReturn(aResponse().withBody('pongFromSecondServer')))
+	}
+
+	def 'should use sticky load balancing strategy taken from Zookeeper dependencies'() {
+		given:
+			String initialResponse = testRibbonClient.pingService('someAlias')
+		expect:
+			5.times {
+				assert testRibbonClient.pingService('someAlias') == initialResponse
+			}
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@EnableDiscoveryClient
+	static class Config {
+
+		@Bean(destroyMethod = 'close')
+		TestingServer testingServer() {
+			return new TestingServer(SocketUtils.findAvailableTcpPort())
+		}
+
+		@Bean(initMethod = "start", destroyMethod = "shutdown") WireMockServer wiremockServerOne() {
+			return new WireMockServer(SocketUtils.findAvailableTcpPort())
+		}
+
+		@Bean(initMethod = "start", destroyMethod = "shutdown") WireMockServer wiremockServerTwo() {
+			return new WireMockServer(SocketUtils.findAvailableTcpPort())
+		}
+
+		@Bean TestRibbonClient testRibbonClient(@LoadBalanced RestTemplate restTemplate) {
+			return new TestRibbonClient(restTemplate)
+		}
+
+		@Bean ZookeeperProperties zookeeperProperties() {
+			return new ZookeeperProperties(connectString: "localhost:${testingServer().port}")
+		}
+
+		@Bean(initMethod = "start", destroyMethod = "stop") TestServiceRegistrar serviceOne(CuratorFramework curatorFramework) {
+			return new TestServiceRegistrar(wiremockServerOne().port(), curatorFramework)
+		}
+
+		@Bean(initMethod = "start", destroyMethod = "stop") TestServiceRegistrar serviceTwo(CuratorFramework curatorFramework) {
+			return new TestServiceRegistrar(wiremockServerTwo().port(), curatorFramework)
+		}
+
+	}
+
+	static class TestRibbonClient extends TestServiceRestClient {
+
+		TestRibbonClient(RestTemplate restTemplate) {
+			super(restTemplate)
+		}
+	}
+}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
@@ -26,14 +26,12 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerClient
 import org.springframework.cloud.zookeeper.ZookeeperProperties
 import org.springframework.cloud.zookeeper.discovery.PollingUtils
 import org.springframework.cloud.zookeeper.discovery.TestServiceRegistrar
-import org.springframework.cloud.zookeeper.discovery.TestServiceRestClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.util.SocketUtils
-import org.springframework.web.client.RestTemplate
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -93,12 +91,5 @@ class StickyRuleISpec extends Specification implements PollingUtils {
 			return new TestServiceRegistrar(SocketUtils.findAvailableTcpPort(), curatorFramework)
 		}
 
-	}
-
-	static class TestRibbonClient extends TestServiceRestClient {
-
-		TestRibbonClient(RestTemplate restTemplate) {
-			super(restTemplate)
-		}
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
@@ -51,8 +51,8 @@ class StickyRuleISpec extends Specification implements PollingUtils {
 	def 'should use sticky load balancing strategy taken from Zookeeper dependencies'() {
 		expect:
 			thereAreTwoRegisteredServices()
+			URI uri = getUriForAlias()
 			conditions.eventually willPass {
-				URI uri = getUriForAlias()
 				2.times {
 					assert uri == getUriForAlias()
 				}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleISpec.groovy
@@ -60,11 +60,11 @@ class StickyRuleISpec extends Specification implements PollingUtils {
 	}
 
 	private boolean thereAreTwoRegisteredServices() {
-		return discoveryClient.getInstances('someAlias').size() == 2
+		return discoveryClient.getInstances('someAlias')?.size() == 2
 	}
 
 	private URI getUriForAlias() {
-		return loadBalancerClient.choose('someAlias').uri
+		return loadBalancerClient.choose('someAlias')?.uri
 	}
 
 

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
@@ -25,29 +25,29 @@ class ZookeeperDependenciesSpec extends Specification {
 		expect:
 			exptectedDependency == zookeeperDependencies.getDependencyForPath(path)
 		where:
-			path   || exptectedDependency
-			null   || null
-			'path' || EXPECTED_DEPENDENCY
+			path          || exptectedDependency
+			'unknownPath' || null
+			'path'        || EXPECTED_DEPENDENCY
 	}
 
 	@Unroll
-	def "should retrieve dependency [#alias] for alias [#alias]"() {
+	def "should retrieve dependency [#exptectedDependency] for alias [#alias]"() {
 		expect:
 			exptectedDependency == zookeeperDependencies.getDependencyForAlias(alias)
 		where:
-			alias   || exptectedDependency
-			null    || null
-			'alias' || EXPECTED_DEPENDENCY
+			alias          || exptectedDependency
+			'unknownAlias' || null
+			'alias'        || EXPECTED_DEPENDENCY
 	}
 
 	@Unroll
-	def "should retrieve alias [#alias] for path [#path]"() {
+	def "should retrieve alias [#expectedAlias] for path [#path]"() {
 		expect:
 			expectedAlias == zookeeperDependencies.getAliasForPath(path)
 		where:
-			path   || expectedAlias
-			null   || ''
-			'path' || 'alias'
+			path          || expectedAlias
+			'unknownPath' || ''
+			'path'        || 'alias'
 	}
 
 	@Unroll
@@ -55,9 +55,9 @@ class ZookeeperDependenciesSpec extends Specification {
 		expect:
 			expectedPath == zookeeperDependencies.getPathForAlias(alias)
 		where:
-			alias   || expectedPath
-			null    || ''
-			'alias' || 'path'
+			alias          || expectedPath
+			'unknownAlias' || ''
+			'alias'        || 'path'
 	}
 
 

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
@@ -21,21 +21,21 @@ class ZookeeperDependenciesSpec extends Specification {
 	ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies(dependencies: DEPENDENCIES)
 
 	@Unroll
-	def "should retrieve dependency [#exptectedDependency] for path [#path]"() {
+	def "should retrieve dependency [#expectedDependency] for path [#path]"() {
 		expect:
-			exptectedDependency == zookeeperDependencies.getDependencyForPath(path)
+			expectedDependency == zookeeperDependencies.getDependencyForPath(path)
 		where:
-			path          || exptectedDependency
+			path          || expectedDependency
 			'unknownPath' || null
 			'path'        || EXPECTED_DEPENDENCY
 	}
 
 	@Unroll
-	def "should retrieve dependency [#exptectedDependency] for alias [#alias]"() {
+	def "should retrieve dependency [#expectedDependency] for alias [#alias]"() {
 		expect:
-			exptectedDependency == zookeeperDependencies.getDependencyForAlias(alias)
+			expectedDependency == zookeeperDependencies.getDependencyForAlias(alias)
 		where:
-			alias          || exptectedDependency
+			alias          || expectedDependency
 			'unknownAlias' || null
 			'alias'        || EXPECTED_DEPENDENCY
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
@@ -1,0 +1,64 @@
+package org.springframework.cloud.zookeeper.discovery.dependency
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ZookeeperDependenciesSpec extends Specification {
+
+	private static final ZookeeperDependencies.ZookeeperDependency EXPECTED_DEPENDENCY = new ZookeeperDependencies.ZookeeperDependency(
+			'id',
+			'path',
+			LoadBalancerType.RANDOM,
+			'contentTypeTemplate',
+			'version',
+			[header: 'value'],
+			false
+	)
+	private static final Map<String, ZookeeperDependencies.ZookeeperDependency> DEPENDENCIES = [
+			alias: EXPECTED_DEPENDENCY
+	]
+
+	ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies(dependencies: DEPENDENCIES)
+
+	@Unroll
+	def "should retrieve dependency [#exptectedDependency] for path [#path]"() {
+		expect:
+			exptectedDependency == zookeeperDependencies.getDependencyForPath(path)
+		where:
+			path   || exptectedDependency
+			null   || null
+			'path' || EXPECTED_DEPENDENCY
+	}
+
+	@Unroll
+	def "should retrieve dependency [#alias] for alias [#alias]"() {
+		expect:
+			exptectedDependency == zookeeperDependencies.getDependencyForAlias(alias)
+		where:
+			alias   || exptectedDependency
+			null    || null
+			'alias' || EXPECTED_DEPENDENCY
+	}
+
+	@Unroll
+	def "should retrieve alias [#alias] for path [#path]"() {
+		expect:
+			expectedAlias == zookeeperDependencies.getAliasForPath(path)
+		where:
+			path   || expectedAlias
+			null   || ''
+			'path' || 'alias'
+	}
+
+	@Unroll
+	def "should retrieve path for alias"() {
+		expect:
+			expectedPath == zookeeperDependencies.getPathForAlias(alias)
+		where:
+			alias   || expectedPath
+			null    || ''
+			'alias' || 'path'
+	}
+
+
+}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
@@ -51,7 +51,7 @@ class ZookeeperDependenciesSpec extends Specification {
 	}
 
 	@Unroll
-	def "should retrieve path for alias"() {
+	def "should retrieve path [#expectedPath] for alias [#alias]"() {
 		expect:
 			expectedPath == zookeeperDependencies.getPathForAlias(alias)
 		where:

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
@@ -23,9 +23,9 @@ import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.client.discovery.DiscoveryClient
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
-import org.springframework.cloud.zookeeper.config.CommonTestConfig
+import org.springframework.cloud.zookeeper.common.CommonTestConfig
+import org.springframework.cloud.zookeeper.common.TestRibbonClient
 import org.springframework.cloud.zookeeper.discovery.PollingUtils
-import org.springframework.cloud.zookeeper.discovery.TestServiceRestClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -103,13 +103,6 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification implements P
 
 		@RequestMapping('/ping') String ping() {
 			return 'pong'
-		}
-	}
-
-	static class TestRibbonClient extends TestServiceRestClient {
-
-		TestRibbonClient(RestTemplate restTemplate) {
-			super(restTemplate)
 		}
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.cloud.zookeeper.discovery
+package org.springframework.cloud.zookeeper.discovery.dependency
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -24,6 +24,8 @@ import org.springframework.cloud.client.discovery.DiscoveryClient
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
 import org.springframework.cloud.zookeeper.config.CommonTestConfig
+import org.springframework.cloud.zookeeper.discovery.PollingUtils
+import org.springframework.cloud.zookeeper.discovery.TestServiceRestClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-dependencies.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-dependencies.yml
@@ -1,0 +1,20 @@
+spring.application.name: nameWithoutAlias
+spring.cloud.zookeeper:
+  dependencies:
+    someAlias:
+      id: someId
+      path: nameWithoutAlias
+      loadBalancerType: ROUND_ROBIN
+      contentTypeTemplate: application/vnd.newsletter.$version+json
+      version: v1
+      headers:
+        header1: value1
+        header2: value2
+      required: false
+    testInstance2:
+      id: someId2
+      path: somePath2
+      loadBalancerType: ROUND_ROBIN
+      contentTypeTemplate: application/vnd.newsletter.$version+json2
+      version: v1
+      required: false

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-loadbalancerclient.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-loadbalancerclient.yml
@@ -1,0 +1,7 @@
+spring.application.name: loadbalancerclient
+spring.cloud.zookeeper:
+  dependencies:
+    someAlias:
+      id: someId
+      path: testInstance
+      loadBalancerType: STICKY

--- a/spring-cloud-zookeeper-discovery/src/test/resources/logback-test.xml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/base.xml"/>
+	<logger name="org.springframework.cloud.zookeeper" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
Bunch of things coming in ;) Don't merge yet - let's see if you like the changes first ;)

ConditionalOnRibbonZookeeper, ConditionalOnDependenciesPassed
=========================

Helper annotations so that we write less code ;)

No longer test output in Travis is redirected to file
=========================

```
script:
'[ "${TRAVIS_PULL_REQUEST}" != "false" ] || mvn --settings .settings.xml deploy -nsu'
'[ "${TRAVIS_PULL_REQUEST}" = "false" ] || mvn --settings .settings.xml install -nsu'
```

DependenciesBasedLoadBalancer
========================

`DependenciesBasedLoadBalancer` is a load balancer that will be turned on if someone provides dependencies explicitly. That way it will load balance basing on what is there in properties.


DependencyRibbonAutoConfiguration and LoadBalancerClient
========================

Ribbon by default has a common configuration for all usages except for those explicitly defined. The `DependencyRibbonAutoConfiguration` contains the `LoadBalancerClient` that at runtime chooses load balancing strategy.

StickyRule
=======================

Candidate for extraction to Ribbon module of Spring Cloud. Once it picks an instance it will stick to it. Ported from Curator.

Tests
=======================

Added PollingConditions and Groovy Trait helper class
