### PR TITLE
solving issue #26: https://github.com/spring-cloud/spring-cloud-zooke…

### DIFF
--- a/spring-cloud-zookeeper-config/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-zookeeper-config/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 # Bootstrap Configuration
 org.springframework.cloud.bootstrap.BootstrapConfiguration=\
-org.springframework.cloud.zookeeper.config.ZookeeperConfigBootstrapConfiguration
+org.springframework.cloud.zookeeper.common.ZookeeperConfigBootstrapConfiguration


### PR DESCRIPTION


spring-cloud-zookeeper-config/src/main/resources/META-INF/spring.factories still references to
org.springframework.cloud.zookeeper.config.ZookeeperConfigBootstrapConfiguration but it was refactored to org.springframework.cloud.zookeeper.common.ZookeeperConfigBootstrapConfiguration. Applications depending on spring-cloud-zookeeper-all are failing with error "ClassNotFoundException" at runtime. Please provide fast support.

Caused by: java.lang.ClassNotFoundException: org.springframework.cloud.zookeeper.config.ZookeeperConfigBootstrapConfiguration
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.LauncherssLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at org.springframework.util.ClassUtils.forName(ClassUtils.java:250)
        at org.springframework.util.ClassUtils.resolveClassName(ClassUtils.java:284)
        ... 14 more      

