### PR TITLE
Headers and Content-Type setting for feign and load balanced rest template with dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,6 @@
 				<groupId>com.netflix.feign</groupId>
 				<artifactId>feign-core</artifactId>
 				<version>8.7.1</version>
-				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-zookeeper-discovery/pom.xml
+++ b/spring-cloud-zookeeper-discovery/pom.xml
@@ -148,12 +148,12 @@
 		<dependency>
 			<groupId>com.netflix.feign</groupId>
 			<artifactId>feign-core</artifactId>
-			<scope>test</scope>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-feign</artifactId>
-			<scope>test</scope>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperRibbonClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperRibbonClientConfiguration.java
@@ -25,6 +25,7 @@ import com.netflix.loadbalancer.ServerList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.zookeeper.discovery.dependency.ConditionalOnDependenciesPassed;
 import org.springframework.cloud.zookeeper.discovery.dependency.DependenciesBasedLoadBalancer;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
@@ -71,6 +72,7 @@ public class ZookeeperRibbonClientConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnDependenciesPassed
+	@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.ribbon.loadbalancer", matchIfMissing = true)
 	public ILoadBalancer dependenciesBasedLoadBalancer(ZookeeperDependencies zookeeperDependencies, ServerList serverList) {
 		return new DependenciesBasedLoadBalancer(zookeeperDependencies, serverList);
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
@@ -42,7 +42,7 @@ import java.util.Map;
 @Configuration
 @ConditionalOnDependenciesPassed
 @ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.headers.enabled", matchIfMissing = true)
-@ConditionalOnClass(Client.class)
+@ConditionalOnClass({Client.class, RibbonClient.class})
 public class DependencyFeignClientAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import feign.Client;
+import feign.Request;
+import feign.Response;
+import feign.ribbon.RibbonClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * Configuration for ensuring that headers are set for a given dependency.
+ *
+ * @author Marcin Grzejszczak, 4financeIT
+ */
+@Configuration
+@ConditionalOnDependenciesPassed
+@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.headers.enabled", matchIfMissing = true)
+@ConditionalOnClass(Client.class)
+public class DependencyFeignClientAutoConfiguration {
+
+	@Bean
+	@Primary
+	Client dependencyBasedFeignClient(final RibbonClient ribbonClient, final ZookeeperDependencies zookeeperDependencies) {
+		return new RibbonClient() {
+			@Override
+			public Response execute(Request request, Request.Options options) throws IOException {
+				URI asUri = URI.create(request.url());
+				String clientName = asUri.getHost();
+				ZookeeperDependencies.ZookeeperDependency dependencyForAlias = zookeeperDependencies.getDependencyForAlias(clientName);
+				Map<String, Collection<String>> headers = getUpdatedHeadersIfPossible(request, dependencyForAlias);
+				return ribbonClient.execute(Request.create(request.method(), request.url(), headers, request.body(), request.charset()), options);
+			}
+
+			private Map<String, Collection<String>> getUpdatedHeadersIfPossible(Request request, ZookeeperDependencies.ZookeeperDependency dependencyForAlias) {
+				if (dependencyForAlias != null) {
+					return Collections.unmodifiableMap(new HashMap<>(dependencyForAlias.getUpdatedHeaders(request.headers())));
+				}
+				return request.headers();
+			}
+
+		};
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRestTemplateAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRestTemplateAutoConfiguration.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.discovery.dependency;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.zookeeper.discovery.ConditionalOnRibbonZookeeper;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.RestTemplate;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * Customizes RestTemplate to support passing of params from dependency
+ *
+ * @author Marcin Grzejszczak, 4financeIT
+ */
+@AutoConfigureAfter(DependencyRibbonAutoConfiguration.class)
+@ConditionalOnRibbonZookeeper
+@Configuration
+@ConditionalOnDependenciesPassed
+@Slf4j
+public class DependencyRestTemplateAutoConfiguration {
+
+	@Autowired @LoadBalanced RestTemplate restTemplate;
+	@Autowired ZookeeperDependencies zookeeperDependencies;
+
+	@PostConstruct
+	void customizeRestTemplate() {
+		restTemplate.getInterceptors().add(new ClientHttpRequestInterceptor() {
+			@Override
+			public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+				String clientName = request.getURI().getHost();
+				ZookeeperDependencies.ZookeeperDependency dependencyForAlias = zookeeperDependencies.getDependencyForAlias(clientName);
+				HttpHeaders headers = getUpdatedHeadersIfPossible(request, dependencyForAlias);
+				request.getHeaders().putAll(headers);
+				return execution.execute(request, body);
+			}
+
+			private HttpHeaders getUpdatedHeadersIfPossible(HttpRequest request, ZookeeperDependencies.ZookeeperDependency dependencyForAlias) {
+				HttpHeaders httpHeaders = new HttpHeaders();
+				if (dependencyForAlias != null) {
+					Map<String, Collection<String>> updatedHeaders = dependencyForAlias.getUpdatedHeaders(convertHeadersFromListToCollection(request.getHeaders()));
+					httpHeaders.putAll(convertHeadersFromCollectionToList(updatedHeaders));
+					return httpHeaders;
+				}
+				httpHeaders.putAll(request.getHeaders());
+				return httpHeaders;
+			}
+
+			private Map<String, Collection<String>> convertHeadersFromListToCollection(HttpHeaders headers) {
+				return Maps.transformValues(headers, new Function<List<String>, Collection<String>>() {
+					@Override
+					public Collection<String> apply(List<String> input) {
+						return input;
+					}
+				});
+			}
+
+			private Map<String, List<String>> convertHeadersFromCollectionToList(Map<String, Collection<String>>  headers) {
+				return Maps.transformValues(headers, new Function<Collection<String>, List<String>>() {
+					@Override
+					public List<String> apply(Collection<String> input) {
+						return (List<String>) input;
+					}
+				});
+			}
+		});
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
@@ -21,6 +21,7 @@ import com.netflix.loadbalancer.Server;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
@@ -45,6 +46,7 @@ public class DependencyRibbonAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@ConditionalOnDependenciesPassed
+	@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.ribbon.enabled", matchIfMissing = true)
 	public LoadBalancerClient loadBalancerClient(SpringClientFactory springClientFactory) {
 		return new RibbonLoadBalancerClient(springClientFactory) {
 			@Override

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.zookeeper.discovery.dependency;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,6 +28,7 @@ import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
 import org.springframework.cloud.netflix.ribbon.RibbonLoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.zookeeper.discovery.ConditionalOnRibbonZookeeper;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -40,12 +42,14 @@ import org.springframework.context.annotation.Configuration;
 @AutoConfigureBefore(RibbonAutoConfiguration.class)
 @ConditionalOnRibbonZookeeper
 @Configuration
+@ConditionalOnDependenciesPassed
 @Slf4j
 public class DependencyRibbonAutoConfiguration {
 
+	@Autowired ApplicationContext applicationContext;
+
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnDependenciesPassed
 	@ConditionalOnProperty(value = "spring.cloud.zookeeper.dependencies.ribbon.enabled", matchIfMissing = true)
 	public LoadBalancerClient loadBalancerClient(SpringClientFactory springClientFactory) {
 		return new RibbonLoadBalancerClient(springClientFactory) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -40,6 +40,10 @@ public class ZookeeperDependencies {
 	 */
 	private String prefix = "";
 
+	/**
+	 * Mapping of alias to ZookeeperDependency. From Ribbon perspective the alias
+	 * is actually serviceID since Ribbon can't accept nested structures in serviceID
+	 */
 	private Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
 
 	@PostConstruct

--- a/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
@@ -3,7 +3,8 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 org.springframework.cloud.zookeeper.discovery.dependency.DependencyRibbonAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.RibbonZookeeperAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependenciesAutoConfiguration,\
-org.springframework.cloud.zookeeper.discovery.watcher.DependencyWatcherAutoConfiguration
+org.springframework.cloud.zookeeper.discovery.watcher.DependencyWatcherAutoConfiguration,\
+org.springframework.cloud.zookeeper.discovery.dependency.DependencyFeignClientAutoConfiguration
 
 org.springframework.cloud.client.discovery.EnableDiscoveryClient=\
 org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryClientConfiguration

--- a/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-zookeeper-discovery/src/main/resources/META-INF/spring.factories
@@ -4,7 +4,8 @@ org.springframework.cloud.zookeeper.discovery.dependency.DependencyRibbonAutoCon
 org.springframework.cloud.zookeeper.discovery.RibbonZookeeperAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependenciesAutoConfiguration,\
 org.springframework.cloud.zookeeper.discovery.watcher.DependencyWatcherAutoConfiguration,\
-org.springframework.cloud.zookeeper.discovery.dependency.DependencyFeignClientAutoConfiguration
+org.springframework.cloud.zookeeper.discovery.dependency.DependencyFeignClientAutoConfiguration,\
+org.springframework.cloud.zookeeper.discovery.dependency.DependencyRestTemplateAutoConfiguration
 
 org.springframework.cloud.client.discovery.EnableDiscoveryClient=\
 org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryClientConfiguration

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/PollingUtils.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/PollingUtils.groovy
@@ -22,7 +22,9 @@ trait PollingUtils {
 			try {
 				closure()
 			} catch (Exception e) {
-				throw new AssertionError("Exception occurred while evaluating closure", e)
+				AssertionError assertionError = new AssertionError("Exception occurred while evaluating closure", e)
+				System.err.println(assertionError)
+				return assertionError
 			}
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesSpec.groovy
@@ -75,5 +75,13 @@ class ZookeeperDependenciesSpec extends Specification {
 			'alias'        || 'path'
 	}
 
-
+	def "should successfully replace version in content type template"() {
+		given:
+			ZookeeperDependencies.ZookeeperDependency zookeeperDependency = new ZookeeperDependencies.ZookeeperDependency(
+					contentTypeTemplate: 'application/vnd.some-service.$version+json',
+					version: 'v1'
+			)
+		expect:
+			'application/vnd.some-service.v1+json' == zookeeperDependency.contentTypeWithVersion
+	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
+++ b/spring-cloud-zookeeper-discovery/src/test/groovy/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesISpec.groovy
@@ -66,7 +66,7 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification implements P
 			}
 	}
 
-	def 'should find a collaborator via Ribbon by using its alias from dependencies'() {
+	def 'should find a collaborator via load balanced rest template by using its alias from dependencies'() {
 		expect:
 			conditions.eventually willPass {
 				assert callingServiceAtBeansEndpointIsNotEmpty()
@@ -77,6 +77,13 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification implements P
 		expect:
 			conditions.eventually willPass {
 				assert aliasUsingFeignClient.beans
+			}
+	}
+
+	def 'should have headers from dependencies attached to the request via load balanced rest template'() {
+		expect:
+			conditions.eventually willPass {
+				callingServiceToCheckIfHeadersArePassed()
 			}
 	}
 
@@ -103,6 +110,10 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification implements P
 
 	private boolean callingServiceViaUrlOnBeansEndpointIsNotEmpty(ServiceInstance instance) {
 		return !testRibbonClient.callOnUrl("${instance.host}:${instance.port}", 'beans').empty
+	}
+
+	private void callingServiceToCheckIfHeadersArePassed() {
+		testRibbonClient.callService('someAlias', 'checkHeaders')
 	}
 
 	@Configuration
@@ -143,10 +154,6 @@ class ZookeeperDiscoveryWithDependenciesISpec extends Specification implements P
 	@RestController
 	@Profile('dependencies')
 	static class PingController {
-
-		PingController() {
-			println 'dupa'
-		}
 
 		@RequestMapping('/ping') String ping() {
 			return 'pong'

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-dependencies.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-dependencies.yml
@@ -8,8 +8,10 @@ spring.cloud.zookeeper:
       contentTypeTemplate: application/vnd.newsletter.$version+json
       version: v1
       headers:
-        header1: value1
-        header2: value2
+        header1:
+          - value1
+        header2:
+          - value2
       required: false
     testInstance2:
       id: someId2

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-watcher.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-watcher.yml
@@ -8,8 +8,10 @@ spring.cloud.zookeeper:
       contentTypeTemplate: application/vnd.newsletter.$version+json
       version: v1
       headers:
-        header1: value1
-        header2: value2
+        header1:
+          - value1
+        header2:
+          - value2
       required: false
     testInstance2:
       id: someId2


### PR DESCRIPTION
- Added some javadocs
- Added contentype from template support
While doing the javadocs it turned out that I forgot about two cool features. FIrst is that in the dependency configuration you can set content type template and the version. The second that you can provide some predefined headers.
- Added support for load balanced rest template

*Note:*
- I've managed to make it work for Feign (although I used a deprecated constructor for RibbonClient).
- For load balanced rest template I used Guava transformations. Maybe you'll have a better idea