### PR TITLE
Conditional for ZookeeperPropertySourceLocator

### DIFF
--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties
 public class ZookeeperConfigBootstrapConfiguration {
 	@Bean
+	@ConditionalOnMissingBean
 	public ZookeeperPropertySourceLocator zookeeperPropertySourceLocator(
 			CuratorFramework curator, ZookeeperConfigProperties properties) {
 		return new ZookeeperPropertySourceLocator(curator, properties);


### PR DESCRIPTION
When "spring.cloud.zookeeper.eanbled=false" getting No qualifying bean of type [org.apache.curator.framework.CuratorFramework] found for dependency