### PR TITLE
Allow implementations of ZookeeperInstance

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDefaultInstance.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDefaultInstance.java
@@ -18,8 +18,33 @@ package org.springframework.cloud.zookeeper.discovery;
 
 /**
  * @author Spencer Gibb
- *
- * Markup interface for zookeeper payload
  */
-public interface ZookeeperInstance {
+public class ZookeeperDefaultInstance implements ZookeeperInstance {
+	private String id;
+	private String name;
+
+	@SuppressWarnings("unused")
+	private ZookeeperDefaultInstance() {
+	}
+
+	public ZookeeperDefaultInstance(String id, String name) {
+			this.id = id;
+			this.name = name;
+	}
+
+	public String getId() {
+			return this.id;
+	}
+
+	public String getName() {
+			return this.name;
+	}
+
+	public void setId(String id) {
+			this.id = id;
+	}
+
+	public void setName(String name) {
+			this.name = name;
+	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceDiscovery.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceDiscovery.java
@@ -114,7 +114,7 @@ public class ZookeeperServiceDiscovery implements ApplicationContextAware {
 		try {
 			serviceInstance.set(ServiceInstance.<ZookeeperInstance>builder()
 					.name(appName)
-					.payload(new ZookeeperInstance(context.getId(), appName))
+					.payload(new ZookeeperDefaultInstance(context.getId(), appName))
 					.port(port.get())
 					.address(host)
 					.uriSpec(uriSpec).build());


### PR DESCRIPTION
Today curator offers possibility to customize the payload used when registering a `ServiceInstance `via `public ServiceInstanceBuilder<T> payload(T payload)`. However spring-cloud-zookeeper only allows `ZookeeperInstance ` to be used as a payload, and this class cannot be subclassed.
As a solution to that problem I simply suggest that we make actual `ZookeeperInstance` an interface instead of a class so it can be easily subclassed and used in a custom `ZookeeperServiceDiscovery`. To handle `ZookeeperServiceDiscovery `default behaviour I simply added a `ZookeeperDefaultInstance `class that matches old `ZookeeperInstance `class.