### PR TITLE
Fix disabling Spring Cloud Zookeeper using spring.cloud.zookeeper.* properties

### DIFF
--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper.config;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +32,7 @@ import org.springframework.context.annotation.Import;
  * @since 1.0.0
  */
 @Configuration
+@ConditionalOnProperty(value = "spring.cloud.zookeeper.enabled", matchIfMissing = true)
 @Import(ZookeeperAutoConfiguration.class)
 @EnableConfigurationProperties
 public class ZookeeperConfigBootstrapConfiguration {


### PR DESCRIPTION
Without "havingValue" on `@ConditionalOnProperty`, Spring Cloud Zookeeper cannot be disabled.

This PR simply adds missing havingValue on existing annotations.
I also added an `@ConditionalOnProperty` on `ZookeeperConfigBootstrapConfiguration`. I thought that this was not necessary since it imports `ZookeeperAutoConfiguration`, but tests proves otherwise.
Still, I may have miss something in Spring Boot behavior.

Hope this helps,
Guillaume