### PR TITLE
Allows setting of instance status.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
@@ -71,6 +71,7 @@ Spring Cloud has support for https://github.com/spring-cloud/spring-cloud-netfli
 
 You can also use the `org.springframework.cloud.client.discovery.DiscoveryClient` which provides a simple API for discovery clients that is not specific to Netflix, e.g.
 
+[source,java,indent=0]
 ----
 @Autowired
 private DiscoveryClient discoveryClient;
@@ -83,6 +84,48 @@ public String serviceUrl() {
     return null;
 }
 ----
+
+[[spring-cloud-zookeeper-netflix]]
+== Using Spring Cloud Zookeeper with Spring Cloud Netflix Components
+
+Spring Cloud Netflix supplies useful tools that work regardless of which `DiscoveryClient` implementation is used. Feign, Turbine, Ribbon and Zuul all work with Spring Cloud Zookeeper.
+
+=== Ribbon with Zookeeper
+
+Spring Cloud Zookeeper provides an implementation of Ribbon's `ServerList`. When the `spring-cloud-starter-zookeeper-discovery` is used, Ribbon is auto-configured to use the `ZookeeperServerList` by default.
+
+[[spring-cloud-zookeeper-service-registry]]
+== Spring Cloud Zookeeper and Service Registry
+
+Spring Cloud Zookeeper implements the `ServiceRegistry` interface allowing developers to register arbitrary service in a programmatic way.
+
+The `ServiceInstanceRegistration` class offers a `builder()` method to create a `Registration` object that can be used by the `ServiceRegistry`.
+
+[source,java,indent=0]
+----
+@Autowired
+private ZookeeperServiceRegistry serviceRegistry;
+
+public void registerThings() {
+    ZookeeperRegistration registration = ServiceInstanceRegistration.builder()
+            .defaultUriSpec()
+            .address("anyUrl")
+            .port(10)
+            .name("/a/b/c/d/anotherservice")
+            .build();
+    this.serviceRegistry.register(registration);
+}
+----
+
+=== Instance Status
+
+Netflix Eureka supports having instances registered with the server that are `OUT_OF_SERVICE` and not returned as active service instances. This is very useful for behaviors such as blue/green deployments. The Curator Service Discovery recipe does not support this behavior. Taking advantage of the flexible payload has let Spring Cloud Zookeeper implement `OUT_OF_SERVICE` by updating some specific metadata and then filtering on that metadata in the Ribbon `ZookeeperServerList`. The `ZookeeperServerList` filters out all non-null instance statuses that do not equal `UP`. If the instance status field is empty, it is considered `UP` for backwards compatibility. To change the status of an instance POST `OUT_OF_SERVICE` to the `ServiceRegistry` instance status actuator endpoint.
+
+ ----
+ $ echo -n OUT_OF_SERVICE | http POST http://localhost:8081/service-registry/instance-status
+ ----
+
+ NOTE: The above example uses the `http` command from https://httpie.org
 
 [[spring-cloud-zookeeper-dependencies]]
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.commons.util.InetUtils;
+import org.springframework.cloud.zookeeper.support.StatusConstants;
 import org.springframework.util.StringUtils;
 
 /**
@@ -76,6 +77,11 @@ public class ZookeeperDiscoveryProperties {
 	 * is sent to zookeeper and can be used by other instances.
 	 */
 	private Map<String, String> metadata = new HashMap<>();
+
+	/**
+	 * The initial status of this instance (defaults to {@link StatusConstants#STATUS_UP}).
+	 */
+	private String initialStatus = StatusConstants.STATUS_UP;
 
 	@SuppressWarnings("unused")
 	private ZookeeperDiscoveryProperties() {}
@@ -155,6 +161,14 @@ public class ZookeeperDiscoveryProperties {
 		this.instancePort = instancePort;
 	}
 
+	public String getInitialStatus() {
+		return this.initialStatus;
+	}
+
+	public void setInitialStatus(String initialStatus) {
+		this.initialStatus = initialStatus;
+	}
+
 	@Override
 	public String toString() {
 		return "ZookeeperDiscoveryProperties{" + "enabled=" + this.enabled +
@@ -164,6 +178,7 @@ public class ZookeeperDiscoveryProperties {
 				", instancePort='" + this.instancePort + '\'' +
 				", metadata=" + this.metadata +
 				", register=" + this.register +
+				", initialStatus=" + this.initialStatus +
 				'}';
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
-import com.netflix.loadbalancer.Server;
-
 import org.apache.curator.x.discovery.ServiceInstance;
 
-import java.util.Objects;
+import com.netflix.loadbalancer.Server;
 
 /**
  * A Zookeeper version of a {@link Server Ribbon Server}
@@ -67,20 +65,5 @@ public class ZookeeperServer extends Server {
 
 	public ServiceInstance<ZookeeperInstance> getInstance() {
 		return this.instance;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		if (!super.equals(o)) return false;
-		ZookeeperServer that = (ZookeeperServer) o;
-		return Objects.equals(this.metaInfo, that.metaInfo) &&
-				Objects.equals(this.instance, that.instance);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(super.hashCode(), this.metaInfo, this.instance);
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
@@ -20,6 +20,8 @@ import com.netflix.loadbalancer.Server;
 
 import org.apache.curator.x.discovery.ServiceInstance;
 
+import java.util.Objects;
+
 /**
  * A Zookeeper version of a {@link Server Ribbon Server}
  *
@@ -29,6 +31,7 @@ import org.apache.curator.x.discovery.ServiceInstance;
 public class ZookeeperServer extends Server {
 
 	private final MetaInfo metaInfo;
+	private ServiceInstance<ZookeeperInstance> instance;
 
 	public ZookeeperServer(final ServiceInstance<ZookeeperInstance> instance) {
 		// TODO: ssl support
@@ -54,10 +57,30 @@ public class ZookeeperServer extends Server {
 				return instance.getId();
 			}
 		};
+		this.instance = instance;
 	}
 
 	@Override
 	public MetaInfo getMetaInfo() {
 		return this.metaInfo;
+	}
+
+	public ServiceInstance<ZookeeperInstance> getInstance() {
+		return instance;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
+		ZookeeperServer that = (ZookeeperServer) o;
+		return Objects.equals(metaInfo, that.metaInfo) &&
+				Objects.equals(instance, that.instance);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), metaInfo, instance);
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
@@ -66,7 +66,7 @@ public class ZookeeperServer extends Server {
 	}
 
 	public ServiceInstance<ZookeeperInstance> getInstance() {
-		return instance;
+		return this.instance;
 	}
 
 	@Override
@@ -75,12 +75,12 @@ public class ZookeeperServer extends Server {
 		if (o == null || getClass() != o.getClass()) return false;
 		if (!super.equals(o)) return false;
 		ZookeeperServer that = (ZookeeperServer) o;
-		return Objects.equals(metaInfo, that.metaInfo) &&
-				Objects.equals(instance, that.instance);
+		return Objects.equals(this.metaInfo, that.metaInfo) &&
+				Objects.equals(this.instance, that.instance);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.hashCode(), metaInfo, instance);
+		return Objects.hash(super.hashCode(), this.metaInfo, this.instance);
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
@@ -88,7 +88,10 @@ public class ZookeeperServerList extends AbstractServerList<ZookeeperServer> {
 			}
 			List<ZookeeperServer> servers = new ArrayList<>();
 			for (ServiceInstance<ZookeeperInstance> instance : instances) {
-				String instanceStatus = instance.getPayload().getMetadata().get(INSTANCE_STATUS_KEY);
+				String instanceStatus = null;
+				if (instance.getPayload() != null && instance.getPayload().getMetadata() != null) {
+					instanceStatus = instance.getPayload().getMetadata().get(INSTANCE_STATUS_KEY);
+				}
 				if (!StringUtils.hasText(instanceStatus) // backwards compatibility
 						|| instanceStatus.equalsIgnoreCase(STATUS_UP)) {
 					servers.add(new ZookeeperServer(instance));

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
@@ -29,6 +29,8 @@ import org.springframework.util.StringUtils;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.AbstractServerList;
 
+import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
+import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_UP;
 import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 
 /**
@@ -74,7 +76,7 @@ public class ZookeeperServerList extends AbstractServerList<ZookeeperServer> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private List<ZookeeperServer> getServers() {
+	protected List<ZookeeperServer> getServers() {
 		try {
 			if (this.serviceDiscovery == null) {
 				return Collections.EMPTY_LIST;
@@ -86,7 +88,11 @@ public class ZookeeperServerList extends AbstractServerList<ZookeeperServer> {
 			}
 			List<ZookeeperServer> servers = new ArrayList<>();
 			for (ServiceInstance<ZookeeperInstance> instance : instances) {
-				servers.add(new ZookeeperServer(instance));
+				String instanceStatus = instance.getPayload().getMetadata().get(INSTANCE_STATUS_KEY);
+				if (!StringUtils.hasText(instanceStatus) // backwards compatibility
+						|| instanceStatus.equalsIgnoreCase(STATUS_UP)) {
+					servers.add(new ZookeeperServer(instance));
+				}
 			}
 			return servers;
 		}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceDiscovery.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceDiscovery.java
@@ -37,6 +37,8 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
+import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
+
 /**
  * Service discovery for Zookeeper that sets up {@link ServiceDiscovery}
  * and {@link ServiceInstance}.
@@ -156,9 +158,13 @@ public class ZookeeperServiceDiscovery implements ZookeeperRegistration, Applica
 											UriSpec uriSpec) {
 		// @formatter:off
 		try {
+			ZookeeperInstance zookeeperInstance = new ZookeeperInstance(context.getId(), appName, this.properties.getMetadata());
+			if (StringUtils.hasText(this.properties.getInitialStatus())) {
+				zookeeperInstance.getMetadata().put(INSTANCE_STATUS_KEY, this.properties.getInitialStatus());
+			}
 			serviceInstance.set(ServiceInstance.<ZookeeperInstance>builder()
 					.name(appName)
-					.payload(new ZookeeperInstance(context.getId(), appName, this.properties.getMetadata()))
+					.payload(zookeeperInstance)
 					.port(port.get())
 					.address(host)
 					.uriSpec(uriSpec).build());

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.support;
+
+/**
+ * @author Spencer Gibb
+ */
+public interface StatusConstants {
+	/**
+	 * Key to the {@link org.springframework.cloud.zookeeper.discovery.ZookeeperInstance#metadata} map.
+	 */
+	String INSTANCE_STATUS_KEY = "instance_status";
+
+	/**
+	 * UP value for {@link StatusConstants#INSTANCE_STATUS_KEY} key.
+	 */
+	String STATUS_UP = "UP";
+}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
@@ -29,4 +29,9 @@ public interface StatusConstants {
 	 * UP value for {@link StatusConstants#INSTANCE_STATUS_KEY} key.
 	 */
 	String STATUS_UP = "UP";
+
+	/**
+	 * OUT_OF_SERVICE value for {@link StatusConstants#INSTANCE_STATUS_KEY} key.
+	 */
+	String STATUS_OUT_OF_SERVICE = "OUT_OF_SERVICE";
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/ZookeeperServerListTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/ZookeeperServerListTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.assertj.core.data.MapEntry;
+import org.junit.Test;
+import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
+import org.springframework.cloud.zookeeper.discovery.ZookeeperServer;
+import org.springframework.cloud.zookeeper.discovery.ZookeeperServerList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
+import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_OUT_OF_SERVICE;
+import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_UP;
+
+/**
+ * @author Spencer Gibb
+ */
+public class ZookeeperServerListTests {
+
+	@Test
+	public void testNullServiceDiscoveryReturnsEmptyList() {
+		ZookeeperServerList serverList = new ZookeeperServerList(null);
+		List<ZookeeperServer> servers = serverList.getInitialListOfServers();
+		assertThat(servers).isEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testEmptyInstancesReturnsEmptyList() throws Exception {
+		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = mock(ServiceDiscovery.class);
+		when(serviceDiscovery.queryForInstances(anyString())).thenReturn(null);
+
+		ZookeeperServerList serverList = new ZookeeperServerList(serviceDiscovery);
+		List<ZookeeperServer> servers = serverList.getInitialListOfServers();
+		assertThat(servers).isEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testGetServers() throws Exception {
+		ArrayList<ServiceInstance<ZookeeperInstance>> instances = new ArrayList<>();
+		instances.add(serviceInstance(1, null));
+
+		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = mock(ServiceDiscovery.class);
+		when(serviceDiscovery.queryForInstances(anyString())).thenReturn(instances);
+
+		ZookeeperServerList serverList = new ZookeeperServerList(serviceDiscovery);
+		List<ZookeeperServer> servers = serverList.getInitialListOfServers();
+		assertThat(servers).hasSize(1);
+	}
+
+	private ServiceInstance<ZookeeperInstance> serviceInstance(int instanceNum, String instanceStatus) {
+		String id = "instance" + instanceNum + "id";
+		String name = "instance" + instanceNum + "name";
+
+		ZookeeperInstance payload = null;
+
+		if (instanceStatus != null) {
+			payload = new ZookeeperInstance(id, name, Collections.singletonMap(INSTANCE_STATUS_KEY, instanceStatus));
+		}
+		String address = "instance" + instanceNum + "addr";
+		int port = 8080 + instanceNum;
+		return new ServiceInstance<>(name, id, address, port, null, payload,
+				0, null, null);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testGetServersWithInstanceStatus() throws Exception {
+		ArrayList<ServiceInstance<ZookeeperInstance>> instances = new ArrayList<>();
+		instances.add(serviceInstance(1, STATUS_UP));
+		instances.add(serviceInstance(2, STATUS_OUT_OF_SERVICE));
+
+		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = mock(ServiceDiscovery.class);
+		when(serviceDiscovery.queryForInstances(anyString())).thenReturn(instances);
+
+		ZookeeperServerList serverList = new ZookeeperServerList(serviceDiscovery);
+		List<ZookeeperServer> servers = serverList.getInitialListOfServers();
+		assertThat(servers).hasSize(1);
+
+		assertThat(servers.get(0).getInstance().getPayload().getMetadata())
+				.contains(MapEntry.entry(INSTANCE_STATUS_KEY, STATUS_UP));
+	}
+}


### PR DESCRIPTION
Uses the metadata field to set an instance_status key. The `ZookeeperServerList` will filter out instances who have a value set that is not UP.

fixes gh-112