### PR TITLE
Curator UriSpec should be used by discovery to produce service instance uri

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
@@ -16,23 +16,20 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
+import static org.springframework.util.ReflectionUtils.*;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 import org.springframework.util.ReflectionUtils;
-
-import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
 
 /**
  * Zookeeper version of {@link DiscoveryClient}. Capable of resolving aliases from
@@ -77,18 +74,7 @@ public class ZookeeperDiscoveryClient implements DiscoveryClient {
 	}
 
 	private static org.springframework.cloud.client.ServiceInstance createServiceInstance(String serviceId, ServiceInstance<ZookeeperInstance> serviceInstance) {
-		boolean secure = serviceInstance.getSslPort() != null;
-		Integer port = serviceInstance.getPort();
-		if (secure) {
-			port = serviceInstance.getSslPort();
-		}
-		Map<String, String> metadata;
-		if (serviceInstance.getPayload() != null) {
-			metadata = serviceInstance.getPayload().getMetadata();
-		} else {
-			metadata = new HashMap<>();
-		}
-		return new DefaultServiceInstance(serviceId, serviceInstance.getAddress(), port, secure, metadata);
+		return new ZookeeperServiceInstance(serviceId, serviceInstance);
 	}
 
 	@Override

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstance.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstance.java
@@ -1,0 +1,74 @@
+package org.springframework.cloud.zookeeper.discovery;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.cloud.client.ServiceInstance;
+
+/**
+ * A specific {@link ServiceInstance} describing a zookeeper service instance
+ * Created on 01/03/17.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+public class ZookeeperServiceInstance implements ServiceInstance {
+
+	private final String serviceId;
+	private final String host;
+	private final int port;
+	private final boolean secure;
+	private final URI uri;
+	private final Map<String, String> metadata;
+
+	/**
+	 * @param serviceId The service id to be used
+	 * @param serviceInstance The zookeeper service instance described by this service instance
+	 */
+	public ZookeeperServiceInstance(String serviceId, org.apache.curator.x.discovery.ServiceInstance<ZookeeperInstance> serviceInstance) {
+		this.serviceId = serviceId;
+		this.host = serviceInstance.getAddress();
+		this.secure = serviceInstance.getSslPort() != null;
+		Integer port = serviceInstance.getPort();
+		if (this.secure) {
+			port = serviceInstance.getSslPort();
+		}
+		this.port = port;
+		this.uri = URI.create(serviceInstance.buildUriSpec());
+		if (serviceInstance.getPayload() != null) {
+			this.metadata = serviceInstance.getPayload().getMetadata();
+		} else {
+			this.metadata = new HashMap<>();
+		}
+	}
+
+	@Override
+	public String getServiceId() {
+		return this.serviceId;
+	}
+
+	@Override
+	public String getHost() {
+		return this.host;
+	}
+
+	@Override
+	public int getPort() {
+		return this.port;
+	}
+
+	@Override
+	public boolean isSecure() {
+		return this.secure;
+	}
+
+	@Override
+	public URI getUri() {
+		return this.uri;
+	}
+
+	@Override
+	public Map<String, String> getMetadata() {
+		return this.metadata;
+	}
+}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
@@ -40,7 +40,10 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZookeeperDiscoveryTests.Config.class,
-		properties = "feign.hystrix.enabled=false",
+		properties = {
+			"feign.hystrix.enabled=false",
+			"spring.cloud.zookeeper.discovery.uriSpec={scheme}://{address}:{port}/contextPath"
+		},
 		webEnvironment = RANDOM_PORT)
 @ActiveProfiles("ribbon")
 @DirtiesContext
@@ -71,6 +74,13 @@ public class ZookeeperDiscoveryTests {
 		ServiceInstance instance = this.discoveryClient.getLocalServiceInstance();
 		//expect:
 		then(this.springAppName).isEqualTo(instance.getServiceId());
+	}
+
+	@Test public void should_service_instance_uri_match_uriSpec() {
+		//given:
+		ServiceInstance instance = this.discoveryClient.getLocalServiceInstance();
+		//expect:
+		then(instance.getUri()).hasPath("/contextPath");
 	}
 
 	@Test public void should_find_an_instance_using_feign_via_service_id() {


### PR DESCRIPTION
It is currently possible to pass `spring.cloud.zookeeper.discovery.uriSpec` property to change the default curator uriSpec.
But `ZookeeperDiscoveryClient` produces a `DefaultServiceInstance` ignoring the `provided uriSpec`.
This is highly problematic when the service uri must contains a `contextPath` (in case of webapp container) in addition to `scheme + host + port`.
Therefore I think that `ZookeeperDiscoveryClient` must return a specific `ServiceInstance` using the `UriSpec` to generate the service uri.