### PR TITLE
Fix ZookeeperProperties warnings

### DIFF
--- a/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperProperties.java
+++ b/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperProperties.java
@@ -20,6 +20,7 @@ import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * Properties related to connecting to Zookeeper
@@ -27,6 +28,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Spencer Gibb
  * @since 1.0.0
  */
+@Validated
 @ConfigurationProperties("spring.cloud.zookeeper")
 public class ZookeeperProperties {
 


### PR DESCRIPTION
```
2017-03-29 12:51:26.220+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
2017-03-29 12:51:26.220+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
2017-03-29 12:51:26.220+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
2017-03-29 12:51:26.240+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
2017-03-29 12:51:26.240+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
2017-03-29 12:51:26.240+0200 | WARN  |  | main | o.s.b.c.p.ConfigurationPropertiesBindingPostProcessor | The @ConfigurationProperties bean class org.springframework.cloud.zookeeper.ZookeeperProperties cont
ains validation constraints but had not been annotated with @Validated.
```