### PR TITLE
update curator dependency to v3.3.0

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
@@ -394,9 +394,6 @@ zookeeper.ssl.trustStore.location="/path/to/your/truststore"
 zookeeper.ssl.trustStore.password="truststore_password"
 ----
 
-In order to make use of the `ClientCnxnSocketNetty` class, you will
-need to add Netty (`io.netty:netty`) as an explicit dependency.
-
 More information on using Zookeeper over SSL is available from
 https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide[the Zookeeper SSL User Guide].
 

--- a/spring-cloud-zookeeper-dependencies/pom.xml
+++ b/spring-cloud-zookeeper-dependencies/pom.xml
@@ -14,7 +14,7 @@
 	<name>spring-cloud-zookeeper-dependencies</name>
 	<description>Spring Cloud Zookeeper Dependencies</description>
 	<properties>
-		<curator.version>2.11.1</curator.version>
+		<curator.version>3.3.0</curator.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -62,10 +62,6 @@
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
 					</exclusion>
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -76,10 +72,6 @@
 					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>
@@ -92,10 +84,6 @@
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
 					</exclusion>
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -107,10 +95,6 @@
 					<exclusion>
 						<groupId>log4j</groupId>
 						<artifactId>log4j</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>io.netty</groupId>
-						<artifactId>netty</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
I realized that a piece of documentation I included in a previous PR was incorrect. Adding netty as a dependency is not sufficient to make the ClientCnxnSocketNetty class available to use for SSL connections. This class is actually in Zookeeper version 3.4.9, and because Curator is currently locked at a version that depends on Zookeeper 3.4.8. I'm proposing to raise the version of curator included in spring-cloud-zookeeper, and also allow netty as a transitive dependency, so this class can be used.

Commits:
Remove incorrect instruction on including ClientCnxnSocketNetty class as
dependency from documentation. Raise Curator version to 3.3.0 so this
class is available. Stop excluding Netty from transitive dependencies.