### PR TITLE
remove SSL section from docs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
@@ -381,25 +381,6 @@ spring:
 * `defaultContext` sets the name used by all applications
 * `profileSeparator` sets the value of the separator used to separate the profile name in property sources with profiles
 
-=== SSL
-The Zookeeper client used by spring-cloud-zookeeper can be configured to connect over SSL by
-setting the following Java system properties:
-
-----
-zookeeper.clientCnxnSocket="org.apache.zookeeper.ClientCnxnSocketNetty"
-zookeeper.client.secure=true
-zookeeper.ssl.keyStore.location="/path/to/your/keystore"
-zookeeper.ssl.keyStore.password="keystore_password"
-zookeeper.ssl.trustStore.location="/path/to/your/truststore"
-zookeeper.ssl.trustStore.password="truststore_password"
-----
-
-In order to make use of the `ClientCnxnSocketNetty` class, you will
-need to add Netty (`io.netty:netty`) as an explicit dependency.
-
-More information on using Zookeeper over SSL is available from
-https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide[the Zookeeper SSL User Guide].
-
 === ACLs
 You can add authentication information for Zookeeper ACLs by calling the addAuthInfo method of a
 CuratorFramework bean. One way to accomplish this is by providing your own CuratorFramework bean:


### PR DESCRIPTION
take out section on SSL connections since it cannot be used until curator is updated to version 3.x.x