### PR TITLE
Fixed checkstyle issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,22 +79,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>${checkstyle.version}</version>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<configuration>
-							<configLocation>checkstyle.xml</configLocation>
-							<headerLocation>LICENSE.txt</headerLocation>
-							<consoleOutput>true</consoleOutput>
-							<failsOnError>true</failsOnError>
-						</configuration>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,33 +72,6 @@
 						</excludes>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>${checkstyle.version}</version>
-					<dependencies>
-						<dependency>
-							<groupId>org.springframework.cloud</groupId>
-							<artifactId>spring-cloud-build-tools</artifactId>
-							<version>${spring-cloud-build.version}</version>
-						</dependency>
-					</dependencies>
-					<executions>
-						<execution>
-							<id>validate</id>
-							<phase>validate</phase>
-							<configuration>
-								<configLocation>checkstyle.xml</configLocation>
-								<headerLocation>LICENSE.txt</headerLocation>
-								<consoleOutput>true</consoleOutput>
-								<failsOnError>true</failsOnError>
-							</configuration>
-							<goals>
-								<goal>check</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
 
 			</plugins>
 		</pluginManagement>
@@ -107,13 +80,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 				<version>${checkstyle.version}</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.springframework.cloud</groupId>
-						<artifactId>spring-cloud-build-tools</artifactId>
-						<version>${spring-cloud-build.version}</version>
-					</dependency>
-				</dependencies>
 				<executions>
 					<execution>
 						<id>validate</id>

--- a/spring-cloud-zookeeper-config/pom.xml
+++ b/spring-cloud-zookeeper-config/pom.xml
@@ -65,6 +65,11 @@
 			<artifactId>curator-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/AbstractZookeeperPropertySource.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/AbstractZookeeperPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.zookeeper.config;
 
 import org.apache.curator.framework.CuratorFramework;
+
 import org.springframework.core.env.EnumerablePropertySource;
 
 /**

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ConfigWatcher.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ConfigWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 package org.springframework.cloud.zookeeper.config;
 
-import javax.annotation.PostConstruct;
 import java.io.Closeable;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,13 +31,10 @@ import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
 import org.apache.curator.framework.recipes.cache.TreeCacheListener;
 import org.apache.zookeeper.KeeperException;
+
 import org.springframework.cloud.endpoint.event.RefreshEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
-
-import static org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type.NODE_ADDED;
-import static org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type.NODE_REMOVED;
-import static org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type.NODE_UPDATED;
 
 /**
  * Class that registers a {@link TreeCache} for each context.
@@ -45,7 +43,7 @@ import static org.apache.curator.framework.recipes.cache.TreeCacheEvent.Type.NOD
  * @author Spencer Gibb
  * @since 1.0.0
  */
-public class ConfigWatcher implements Closeable, TreeCacheListener, ApplicationEventPublisherAware{
+public class ConfigWatcher implements Closeable, TreeCacheListener, ApplicationEventPublisherAware {
 
 	private static final Log log = LogFactory.getLog(ConfigWatcher.class);
 
@@ -80,10 +78,12 @@ public class ConfigWatcher implements Closeable, TreeCacheListener, ApplicationE
 					this.caches.put(context, cache);
 					// no race condition since ZookeeperAutoConfiguration.curatorFramework
 					// calls curator.blockUntilConnected
-				} catch (KeeperException.NoNodeException e) {
+				}
+				catch (KeeperException.NoNodeException kenne) {
 					// no node, ignore
-				} catch (Exception e) {
-					log.error("Error initializing listener for context " + context, e);
+				}
+				catch (Exception ex) {
+					log.error("Error initializing listener for context " + context, ex);
 				}
 			}
 		}
@@ -102,7 +102,7 @@ public class ConfigWatcher implements Closeable, TreeCacheListener, ApplicationE
 	@Override
 	public void childEvent(CuratorFramework client, TreeCacheEvent event) throws Exception {
 		TreeCacheEvent.Type eventType = event.getType();
-		if (eventType == NODE_ADDED || eventType == NODE_REMOVED || eventType == NODE_UPDATED) {
+		if (eventType == TreeCacheEvent.Type.NODE_ADDED || eventType == TreeCacheEvent.Type.NODE_REMOVED || eventType == TreeCacheEvent.Type.NODE_UPDATED) {
 			this.publisher.publishEvent(new RefreshEvent(this, event, getEventDesc(event)));
 		}
 	}

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigAutoConfiguration.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.zookeeper.config;
 
 import org.apache.curator.framework.CuratorFramework;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.endpoint.RefreshEndpoint;
@@ -36,6 +37,10 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(value = "spring.cloud.zookeeper.config.enabled", matchIfMissing = true)
 public class ZookeeperConfigAutoConfiguration {
 
+	/**
+	 * {@link org.springframework.context.annotation.Configuration Configuration}
+	 * that registers a Zookeeper configuration watcher.
+	 */
 	@Configuration
 	@ConditionalOnClass(RefreshEndpoint.class)
 	protected static class ZkRefreshConfiguration {

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.zookeeper.config;
 
 import org.apache.curator.framework.CuratorFramework;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.zookeeper.ConditionalOnZookeeperEnabled;
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;
@@ -25,7 +26,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Bootstrap Configuration for Zookeeper Configuration
+ * Bootstrap Configuration for Zookeeper Configuration.
  *
  * @author Spencer Gibb
  * @since 1.0.0

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigProperties.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.cloud.zookeeper.config;
 
 import org.hibernate.validator.constraints.NotEmpty;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -34,18 +35,18 @@ public class ZookeeperConfigProperties {
 	private boolean enabled = true;
 
 	/**
-	 * Root folder where the configuration for Zookeeper is kept
+	 * Root folder where the configuration for Zookeeper is kept.
 	 */
 	private String root = "config";
 
 	/**
-	 * The name of the default context
+	 * The name of the default context.
 	 */
 	@NotEmpty
 	private String defaultContext = "application";
 
 	/**
-	 * Separator for profile appended to the application name
+	 * Separator for profile appended to the application name.
 	 */
 	@NotEmpty
 	private String profileSeparator = ",";

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySource.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
+
 import org.springframework.util.ReflectionUtils;
 
 /**
@@ -56,13 +57,15 @@ public class ZookeeperPropertySource extends AbstractZookeeperPropertySource {
 			byte[] bytes = null;
 			try {
 				bytes = this.getSource().getData().forPath(fullPath);
-			} catch (KeeperException e) {
-				if (e.code() != KeeperException.Code.NONODE) { // not found
-					throw e;
+			}
+			catch (KeeperException ke) {
+				if (ke.code() != KeeperException.Code.NONODE) { // not found
+					throw ke;
 				}
 			}
 			return bytes;
-		} catch (Exception exception) {
+		}
+		catch (Exception exception) {
 			ReflectionUtils.rethrowRuntimeException(exception);
 		}
 		return null;
@@ -92,7 +95,8 @@ public class ZookeeperPropertySource extends AbstractZookeeperPropertySource {
 					if (childPathChildren == null || childPathChildren.isEmpty()) {
 						registerKeyValue(childPath, "");
 					}
-				} else {
+				}
+				else {
 					registerKeyValue(childPath, new String(bytes, Charset.forName("UTF-8")));
 				}
 
@@ -100,7 +104,8 @@ public class ZookeeperPropertySource extends AbstractZookeeperPropertySource {
 				findProperties(childPath, childPathChildren);
 			}
 			log.trace("leaving findProperties for path: " + path);
-		} catch (Exception exception) {
+		}
+		catch (Exception exception) {
 			ReflectionUtils.rethrowRuntimeException(exception);
 		}
 	}
@@ -114,9 +119,10 @@ public class ZookeeperPropertySource extends AbstractZookeeperPropertySource {
 		List<String> children = null;
 		try {
 			children = this.getSource().getChildren().forPath(path);
-		} catch (KeeperException e) {
-			if (e.code() != KeeperException.Code.NONODE) { // not found
-				throw e;
+		}
+		catch (KeeperException ke) {
+			if (ke.code() != KeeperException.Code.NONODE) { // not found
+				throw ke;
 			}
 		}
 		return children;

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocator.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,17 @@
 
 package org.springframework.cloud.zookeeper.config;
 
-import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.PreDestroy;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
+
 import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
 import org.springframework.core.env.CompositePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
@@ -48,7 +50,6 @@ import org.springframework.util.ReflectionUtils;
  * config/application
  * }</pre>
  *
- * </p>
  * The most specific property source is at the top, with the least specific at the
  * bottom.  Properties is the {@code config/application} namespace are applicable to all applications
  * using zookeeper for configuration.  Properties in the {@code config/testApp} namespace are only available
@@ -112,11 +113,13 @@ public class ZookeeperPropertySourceLocator implements PropertySourceLocator {
 					PropertySource propertySource = create(propertySourceContext);
 					composite.addPropertySource(propertySource);
 					// TODO: howto call close when /refresh
-				} catch (Exception e) {
+				}
+				catch (Exception ex) {
 					if (this.properties.isFailFast()) {
-						ReflectionUtils.rethrowRuntimeException(e);
-					} else {
-						log.warn("Unable to load zookeeper config from " + propertySourceContext, e);
+						ReflectionUtils.rethrowRuntimeException(ex);
+					}
+					else {
+						log.warn("Unable to load zookeeper config from " + propertySourceContext, ex);
 					}
 				}
 			}

--- a/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigAutoConfigurationTests.java
+++ b/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperConfigAutoConfigurationTests.java
@@ -1,79 +1,96 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.config;
 
+import java.net.ConnectException;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import java.net.ConnectException;
-
 /**
  * @author Cesar Aguilera
  */
 public class ZookeeperConfigAutoConfigurationTests {
 
-    @Rule
-    public ExpectedException expectedException;
+	@Rule
+	public ExpectedException expectedException;
 
-    @Before
-    public void setUp() throws Exception {
-        expectedException = ExpectedException.none();
-        // makes Curator fail faster, otherwise it takes 15 seconds to trigger a retry
-        System.setProperty("curator-default-connection-timeout", "0");
-    }
+	@Before
+	public void setUp() throws Exception {
+		this.expectedException = ExpectedException.none();
+		// makes Curator fail faster, otherwise it takes 15 seconds to trigger a retry
+		System.setProperty("curator-default-connection-timeout", "0");
+	}
 
-    @After
-    public void tearDown() throws Exception {
-        System.clearProperty("curator-default-connection-timeout");
-    }
+	@After
+	public void tearDown() throws Exception {
+		System.clearProperty("curator-default-connection-timeout");
+	}
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
-    public void testConfigEnabledFalseDoesNotLoadZookeeperConfigAutoConfiguration() throws Exception {
-        ConfigurableApplicationContext context = new SpringApplicationBuilder()
-                .sources(Config.class)
-                .web(WebApplicationType.NONE)
-                .run(
-                        "--spring.application.name=testZookeeperConfigEnabledSetToFalse",
-                        "--spring.jmx.default-domain=testZookeeperConfigEnabledSetToFalse",
-                        "--spring.cloud.zookeeper.config.connectString=localhost:2188",
-                        "--spring.cloud.zookeeper.baseSleepTimeMs=0",
-                        "--spring.cloud.zookeeper.maxRetries=0",
-                        "--spring.cloud.zookeeper.maxSleepMs=0",
-                        "--spring.cloud.zookeeper.blockUntilConnectedWait=0",
-                        "--spring.cloud.zookeeper.config.failFast=false",
-                        "--spring.cloud.zookeeper.config.enabled=false"
-                );
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void testConfigEnabledFalseDoesNotLoadZookeeperConfigAutoConfiguration() throws Exception {
+		ConfigurableApplicationContext context = new SpringApplicationBuilder()
+				.sources(Config.class)
+				.web(WebApplicationType.NONE)
+				.run(
+						"--spring.application.name=testZookeeperConfigEnabledSetToFalse",
+						"--spring.jmx.default-domain=testZookeeperConfigEnabledSetToFalse",
+						"--spring.cloud.zookeeper.config.connectString=localhost:2188",
+						"--spring.cloud.zookeeper.baseSleepTimeMs=0",
+						"--spring.cloud.zookeeper.maxRetries=0",
+						"--spring.cloud.zookeeper.maxSleepMs=0",
+						"--spring.cloud.zookeeper.blockUntilConnectedWait=0",
+						"--spring.cloud.zookeeper.config.failFast=false",
+						"--spring.cloud.zookeeper.config.enabled=false"
+				);
 
+		context.getBean(ZookeeperConfigAutoConfiguration.class);
+	}
 
-        context.getBean(ZookeeperConfigAutoConfiguration.class);
-    }
+	@Test
+	public void testConfigEnabledTrueLoadsZookeeperConfigAutoConfiguration() throws Exception {
+		this.expectedException.expect(ConnectException.class);
 
+		new SpringApplicationBuilder()
+				.sources(Config.class)
+				.web(WebApplicationType.NONE)
+				.run(
+						"--spring.application.name=testZookeeperConfigEnabledSetToTrue",
+						"--spring.jmx.default-domain=testZookeeperConfigEnabledSetToTrue",
+						"--spring.cloud.zookeeper.config.connectString=localhost:2188",
+						"--spring.cloud.zookeeper.baseSleepTimeMs=0",
+						"--spring.cloud.zookeeper.maxRetries=0",
+						"--spring.cloud.zookeeper.maxSleepMs=0",
+						"--spring.cloud.zookeeper.blockUntilConnectedWait=0",
+						"--spring.cloud.zookeeper.config.failFast=false",
+						"--spring.cloud.zookeeper.config.enabled=true"
+				);
+	}
 
-    @Test
-    public void testConfigEnabledTrueLoadsZookeeperConfigAutoConfiguration() throws Exception {
-        expectedException.expect(ConnectException.class);
-
-        new SpringApplicationBuilder()
-                .sources(Config.class)
-                .web(WebApplicationType.NONE)
-                .run(
-                        "--spring.application.name=testZookeeperConfigEnabledSetToTrue",
-                        "--spring.jmx.default-domain=testZookeeperConfigEnabledSetToTrue",
-                        "--spring.cloud.zookeeper.config.connectString=localhost:2188",
-                        "--spring.cloud.zookeeper.baseSleepTimeMs=0",
-                        "--spring.cloud.zookeeper.maxRetries=0",
-                        "--spring.cloud.zookeeper.maxSleepMs=0",
-                        "--spring.cloud.zookeeper.blockUntilConnectedWait=0",
-                        "--spring.cloud.zookeeper.config.failFast=false",
-                        "--spring.cloud.zookeeper.config.enabled=true"
-                );
-    }
-
-    @SpringBootApplication
-    static class Config {
-    }
+	@SpringBootApplication
+	static class Config {
+	}
 }

--- a/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocatorFailFastTests.java
+++ b/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocatorFailFastTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -61,7 +62,7 @@ public class ZookeeperPropertySourceLocatorFailFastTests {
 
 	@Test
 	public void testFailFastTrueDoesNotLoadTheApplicationContext() throws Exception {
-		expectedException.expect(Exception.class);
+		this.expectedException.expect(Exception.class);
 
 		new SpringApplicationBuilder()
 			.sources(Config.class)

--- a/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocatorNoApplicationNameTests.java
+++ b/spring-cloud-zookeeper-config/src/test/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocatorNoApplicationNameTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,11 @@ package org.springframework.cloud.zookeeper.config;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.GetChildrenBuilder;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Configuration;
+
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.when;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-zookeeper-core/pom.xml
+++ b/spring-cloud-zookeeper-core/pom.xml
@@ -99,6 +99,11 @@
 			<artifactId>groovy</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ConditionalOnZookeeperEnabled.java
+++ b/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ConditionalOnZookeeperEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ import java.lang.annotation.Target;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
- * Wrapper annotation to enable Zookeeper
+ * Wrapper annotation to enable Zookeeper.
  *
+ * @author Marcin Grzejszczak
  * @since 1.1.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfiguration.java
+++ b/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
@@ -63,7 +64,8 @@ public class ZookeeperAutoConfiguration {
 		CuratorFrameworkFactory.Builder builder = CuratorFrameworkFactory.builder();
 		if (this.ensembleProvider != null) {
 			builder.ensembleProvider(this.ensembleProvider);
-		} else {
+		}
+		else {
 			builder.connectString(properties.getConnectString());
 		}
 		CuratorFramework curator = builder.retryPolicy(retryPolicy).build();
@@ -82,6 +84,10 @@ public class ZookeeperAutoConfiguration {
 				properties.getMaxSleepMs());
 	}
 
+	/**
+	 * {@link org.springframework.context.annotation.Configuration Configuration}
+	 * that sets up the Zookeeper health indicator.
+	 */
 	@Configuration
 	@ConditionalOnClass(Endpoint.class)
 	protected static class ZookeeperHealthConfig {

--- a/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperHealthIndicator.java
+++ b/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
+
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 
@@ -51,8 +52,8 @@ public class ZookeeperHealthIndicator extends AbstractHealthIndicator {
 					this.curator.getZookeeperClient().getCurrentConnectionString())
 					.withDetail("state", this.curator.getState());
 		}
-		catch (Exception e) {
-			builder.down(e);
+		catch (Exception ex) {
+			builder.down(ex);
 		}
 	}
 }

--- a/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperProperties.java
+++ b/spring-cloud-zookeeper-core/src/main/java/org/springframework/cloud/zookeeper/ZookeeperProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,15 @@
 
 package org.springframework.cloud.zookeeper;
 
-import javax.validation.constraints.NotNull;
 import java.util.concurrent.TimeUnit;
+
+import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Properties related to connecting to Zookeeper
+ * Properties related to connecting to Zookeeper.
  *
  * @author Spencer Gibb
  * @since 1.0.0
@@ -33,38 +34,38 @@ import org.springframework.validation.annotation.Validated;
 public class ZookeeperProperties {
 
 	/**
-	 * Connection string to the Zookeeper cluster
+	 * Connection string to the Zookeeper cluster.
 	 */
 	@NotNull
 	private String connectString = "localhost:2181";
 
 	/**
-	 * Is Zookeeper enabled
+	 * Is Zookeeper enabled.
 	 */
 	private boolean enabled = true;
 
 	/**
-	 * Initial amount of time to wait between retries
+	 * Initial amount of time to wait between retries.
 	 */
 	private Integer baseSleepTimeMs = 50;
 
 	/**
-	 * Max number of times to retry
+	 * Max number of times to retry.
 	 */
 	private Integer maxRetries = 10;
 
 	/**
-	 * Max time in ms to sleep on each retry
+	 * Max time in ms to sleep on each retry.
 	 */
 	private Integer maxSleepMs = 500;
 
 	/**
-	 * Wait time to block on connection to Zookeeper
+	 * Wait time to block on connection to Zookeeper.
 	 */
 	private Integer blockUntilConnectedWait = 10;
 
 	/**
-	 * The unit of time related to blocking on connection to Zookeeper
+	 * The unit of time related to blocking on connection to Zookeeper.
 	 */
 	private TimeUnit blockUntilConnectedUnit = TimeUnit.SECONDS;
 

--- a/spring-cloud-zookeeper-core/src/test/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfigurationEnsembleTests.java
+++ b/spring-cloud-zookeeper-core/src/test/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfigurationEnsembleTests.java
@@ -1,7 +1,20 @@
-package org.springframework.cloud.zookeeper;
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+package org.springframework.cloud.zookeeper;
 
 import org.apache.curator.ensemble.EnsembleProvider;
 import org.apache.curator.ensemble.fixed.FixedEnsembleProvider;
@@ -9,10 +22,13 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Konrad Kamil Dobrzyński
@@ -21,14 +37,16 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(classes = { ZookeeperAutoConfigurationEnsembleTests.TestConfig.class, ZookeeperAutoConfiguration.class })
 public class ZookeeperAutoConfigurationEnsembleTests {
 
-	@Autowired(required = false) CuratorFramework curator;
+	@Autowired(required = false)
+	CuratorFramework curator;
 
-	@Autowired TestingServer testingServer;
-	
+	@Autowired
+	TestingServer testingServer;
+
 	@Test
 	public void should_successfully_inject_Curator_with_ensemble_connection_string() {
-		assertEquals(testingServer.getConnectString(), curator.getZookeeperClient().getCurrentConnectionString());
-		assertNotEquals(TestConfig.DUMMY_CONNECTION_STRING, curator.getZookeeperClient().getCurrentConnectionString());
+		assertThat(this.testingServer.getConnectString()).isEqualTo(this.curator.getZookeeperClient().getCurrentConnectionString());
+		assertThat(TestConfig.DUMMY_CONNECTION_STRING).isNotEqualTo(this.curator.getZookeeperClient().getCurrentConnectionString());
 	}
 
 	static class TestConfig {
@@ -36,7 +54,7 @@ public class ZookeeperAutoConfigurationEnsembleTests {
 		static final String DUMMY_CONNECTION_STRING = "dummy-connection-string:2111";
 
 		@Bean
-		EnsembleProvider ensembleProvider(TestingServer testingServer){
+		EnsembleProvider ensembleProvider(TestingServer testingServer) {
 			return new FixedEnsembleProvider(testingServer.getConnectString());
 		}
 
@@ -47,7 +65,8 @@ public class ZookeeperAutoConfigurationEnsembleTests {
 			return properties;
 		}
 
-		@Bean(destroyMethod = "close") TestingServer testingServer() throws Exception {
+		@Bean(destroyMethod = "close")
+		TestingServer testingServer() throws Exception {
 			return new TestingServer();
 		}
 	}

--- a/spring-cloud-zookeeper-core/src/test/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfigurationTests.java
+++ b/spring-cloud-zookeeper-core/src/test/java/org/springframework/cloud/zookeeper/ZookeeperAutoConfigurationTests.java
@@ -1,15 +1,32 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -18,11 +35,12 @@ import static org.junit.Assert.assertNotNull;
 @ContextConfiguration(classes = { ZookeeperAutoConfigurationTests.TestConfig.class, ZookeeperAutoConfiguration.class })
 public class ZookeeperAutoConfigurationTests {
 
-	@Autowired(required = false) CuratorFramework curator;
-	
+	@Autowired(required = false)
+	CuratorFramework curator;
+
 	@Test
 	public void should_successfully_inject_Curator_as_a_Spring_bean() {
-		assertNotNull(this.curator);
+		assertThat(this.curator).isNotNull();
 	}
 
 	static class TestConfig {
@@ -33,7 +51,8 @@ public class ZookeeperAutoConfigurationTests {
 			return properties;
 		}
 
-		@Bean(destroyMethod = "close") TestingServer testingServer() throws Exception {
+		@Bean(destroyMethod = "close")
+		TestingServer testingServer() throws Exception {
 			return new TestingServer();
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnRibbonZookeeper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,10 @@ import java.lang.annotation.Target;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 /**
- * Wrapper annotation to enable Ribbon for Zookeeper
+ * Wrapper annotation to enable Ribbon for Zookeeper.
  *
+ * @author Marcin Grzejszczak
+ * @author Spencer Gibb
  * @since 1.0.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnZookeeperDiscoveryEnabled.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ConditionalOnZookeeperDiscoveryEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.zookeeper.ConditionalOnZookeeperEnabled;
 
 /**
- * Wrapper annotation to enable Zookeeper Discovery
+ * Wrapper annotation to enable Zookeeper Discovery.
  *
+ * @author Marcin Grzejszczak
  * @since 1.1.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/DependencyPathUtils.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/DependencyPathUtils.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 /**
- * Utils for correct dependency path format
+ * Utils for correct dependency path format.
  *
  * @author Denis Stepanov
  * @since 1.0.4
@@ -9,9 +25,10 @@ package org.springframework.cloud.zookeeper.discovery;
 public class DependencyPathUtils {
 
 	/**
-	 * Sanitizes path by ensuring that path starts with a slash and doesn't have one at the end
-	 * @param path
-	 * @return
+	 * Sanitizes path by ensuring that path starts with a slash and doesn't have one at the end.
+	 *
+	 * @param path the path that needs to be sanitized
+	 * @return the sanitized path
 	 */
 	public static String sanitize(String path) {
 		return withLeadingSlash(withoutSlashAtEnd(path));

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/RibbonZookeeperAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/RibbonZookeeperAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper.discovery;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.ServiceDiscovery;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
@@ -34,14 +35,17 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * that sets up service discovery with Zookeeper.
+ *
  * @author Spencer Gibb
  * @since 1.1.0
  */
 @Configuration
 @ConditionalOnBean(ZookeeperDiscoveryClientConfiguration.Marker.class)
 @ConditionalOnZookeeperDiscoveryEnabled
-@AutoConfigureBefore({CommonsClientAutoConfiguration.class, NoopDiscoveryClientAutoConfiguration.class})
-@AutoConfigureAfter({ZookeeperDiscoveryClientConfiguration.class})
+@AutoConfigureBefore({ CommonsClientAutoConfiguration.class, NoopDiscoveryClientAutoConfiguration.class })
+@AutoConfigureAfter({ ZookeeperDiscoveryClientConfiguration.class })
 public class ZookeeperDiscoveryAutoConfiguration {
 
 	@Autowired(required = false)
@@ -66,6 +70,16 @@ public class ZookeeperDiscoveryAutoConfiguration {
 				zookeeperDiscoveryProperties);
 	}
 
+	@Bean
+	public ZookeeperServiceWatch zookeeperServiceWatch(ZookeeperDiscoveryProperties zookeeperDiscoveryProperties) {
+		return new ZookeeperServiceWatch(this.curator, zookeeperDiscoveryProperties);
+	}
+
+
+	/**
+	 * {@link org.springframework.context.annotation.Configuration configuration}
+	 * that sets up a {@link org.springframework.boot.actuate.health.HealthIndicator}.
+	 */
 	@Configuration
 	@ConditionalOnEnabledHealthIndicator("zookeeper")
 	@ConditionalOnClass(Endpoint.class)
@@ -82,11 +96,6 @@ public class ZookeeperDiscoveryAutoConfiguration {
 			return new ZookeeperDiscoveryHealthIndicator(curatorFramework,
 					serviceDiscovery, this.zookeeperDependencies, properties);
 		}
-	}
-
-	@Bean
-	public ZookeeperServiceWatch zookeeperServiceWatch(ZookeeperDiscoveryProperties zookeeperDiscoveryProperties) {
-		return new ZookeeperServiceWatch(this.curator, zookeeperDiscoveryProperties);
 	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ import org.apache.zookeeper.KeeperException;
 
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
-
-import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * Zookeeper version of {@link DiscoveryClient}. Capable of resolving aliases from
@@ -80,14 +79,16 @@ public class ZookeeperDiscoveryClient implements DiscoveryClient {
 				instances.add(createServiceInstance(serviceIdToQuery, instance));
 			}
 			return instances;
-		} catch (KeeperException.NoNodeException e) {
+		}
+		catch (KeeperException.NoNodeException kenne) {
 			if (log.isDebugEnabled()) {
-				log.debug("Error getting instances from zookeeper. Possibly, no service has registered.", e);
+				log.debug("Error getting instances from zookeeper. Possibly, no service has registered.", kenne);
 			}
 			// this means that nothing has registered as a service yes
 			return Collections.emptyList();
-		} catch (Exception exception) {
-			rethrowRuntimeException(exception);
+		}
+		catch (Exception exception) {
+			ReflectionUtils.rethrowRuntimeException(exception);
 		}
 		return new ArrayList<>();
 	}
@@ -118,15 +119,15 @@ public class ZookeeperDiscoveryClient implements DiscoveryClient {
 			}
 			services = new ArrayList<>(names);
 		}
-		catch (KeeperException.NoNodeException e) {
+		catch (KeeperException.NoNodeException kenne) {
 			if (log.isDebugEnabled()) {
-				log.debug("Error getting services from zookeeper. Possibly, no service has registered.", e);
+				log.debug("Error getting services from zookeeper. Possibly, no service has registered.", kenne);
 			}
 			// this means that nothing has registered as a service yes
 			return Collections.emptyList();
 		}
-		catch (Exception e) {
-			rethrowRuntimeException(e);
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 		return services;
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,11 +31,15 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(value = "spring.cloud.zookeeper.discovery.enabled", matchIfMissing = true)
 public class ZookeeperDiscoveryClientConfiguration {
 
-	class Marker {}
-
 	@Bean
 	public Marker zookeeperDiscoveryClientMarker() {
 		return new Marker();
+	}
+
+	/**
+	 * Marker class to indicate that Zookeeper discovery is enabled.
+	 */
+	class Marker {
 	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicator.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
+
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.cloud.client.discovery.health.DiscoveryHealthIndicator;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
@@ -67,9 +68,9 @@ public class ZookeeperDiscoveryHealthIndicator implements DiscoveryHealthIndicat
 						this.zookeeperDiscoveryProperties);
 			builder.up().withDetail("services", allInstances);
 		}
-		catch (Exception e) {
-			log.error("Error", e);
-			builder.down(e);
+		catch (Exception ex) {
+			log.error("Error", ex);
+			builder.down(ex);
 		}
 
 		return builder.build();

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,9 @@ import org.springframework.util.StringUtils;
 @ConfigurationProperties("spring.cloud.zookeeper.discovery")
 public class ZookeeperDiscoveryProperties {
 
+	/**
+	 * The default URI spec.
+	 */
 	public static final String DEFAULT_URI_SPEC = "{scheme}://{address}:{port}";
 
 	private InetUtils.HostInfo hostInfo;
@@ -40,12 +43,12 @@ public class ZookeeperDiscoveryProperties {
 	private boolean enabled = true;
 
 	/**
-	 * Root Zookeeper folder in which all instances are registered
+	 * Root Zookeeper folder in which all instances are registered.
 	 */
 	private String root = "/services";
 
 	/**
-	 * The URI specification to resolve during service registration in Zookeeper
+	 * The URI specification to resolve during service registration in Zookeeper.
 	 */
 	private String uriSpec = DEFAULT_URI_SPEC;
 
@@ -59,15 +62,15 @@ public class ZookeeperDiscoveryProperties {
 	private String instanceHost;
 
 	/** IP address to use when accessing service (must also set preferIpAddress
-            to use) */
+            to use). */
 	private String instanceIpAddress;
 
 	/**
-	 * Use ip address rather than hostname during registration
+	 * Use ip address rather than hostname during registration.
 	 */
 	private boolean preferIpAddress = false;
 
-	/** Port to register the service under (defaults to listening port) */
+	/** Port to register the service under (defaults to listening port). */
 	private Integer instancePort;
 
 	/** Ssl port of the registered service. */
@@ -95,7 +98,8 @@ public class ZookeeperDiscoveryProperties {
 	private int order = 0;
 
 	// Visible for Testing
-	protected ZookeeperDiscoveryProperties() {}
+	protected ZookeeperDiscoveryProperties() {
+	}
 
 	public ZookeeperDiscoveryProperties(InetUtils inetUtils) {
 		this.hostInfo = inetUtils.findFirstNonLoopbackHostInfo();

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperInstance.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperRibbonClientConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperRibbonClientConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,19 @@ package org.springframework.cloud.zookeeper.discovery;
 
 import javax.annotation.PostConstruct;
 
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicStringProperty;
+import com.netflix.loadbalancer.ILoadBalancer;
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.PingUrl;
+import com.netflix.loadbalancer.ServerList;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.x.discovery.ServiceDiscovery;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,18 +41,6 @@ import org.springframework.cloud.zookeeper.discovery.dependency.DependenciesBase
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import com.netflix.client.config.IClientConfig;
-import com.netflix.config.ConfigurationManager;
-import com.netflix.config.DynamicPropertyFactory;
-import com.netflix.config.DynamicStringProperty;
-import com.netflix.loadbalancer.ILoadBalancer;
-import com.netflix.loadbalancer.IPing;
-import com.netflix.loadbalancer.PingUrl;
-import com.netflix.loadbalancer.ServerList;
-
-import static com.netflix.client.config.CommonClientConfigKey.DeploymentContextBasedVipAddresses;
-import static com.netflix.client.config.CommonClientConfigKey.EnableZoneAffinity;
 
 /**
  * Preprocessor that configures defaults for zookeeper-discovered ribbon clients. Such as:
@@ -114,8 +112,8 @@ public class ZookeeperRibbonClientConfiguration {
 
 	@PostConstruct
 	public void preprocess() {
-		setProp(this.serviceId, DeploymentContextBasedVipAddresses.key(), this.serviceId);
-		setProp(this.serviceId, EnableZoneAffinity.key(), "true");
+		setProp(this.serviceId, CommonClientConfigKey.DeploymentContextBasedVipAddresses.key(), this.serviceId);
+		setProp(this.serviceId, CommonClientConfigKey.EnableZoneAffinity.key(), "true");
 	}
 
 	protected void setProp(String serviceId, String suffix, String value) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
+import com.netflix.loadbalancer.Server;
 import org.apache.curator.x.discovery.ServiceInstance;
 
-import com.netflix.loadbalancer.Server;
-
 /**
- * A Zookeeper version of a {@link Server Ribbon Server}
+ * A Zookeeper version of a {@link Server Ribbon Server}.
  *
  * @author Spencer Gibb
  * @since 1.0.0

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerIntrospector.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerIntrospector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,17 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
-import com.netflix.loadbalancer.Server;
-import org.apache.curator.x.discovery.ServiceInstance;
-import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
-
 import java.util.Map;
 
+import com.netflix.loadbalancer.Server;
+import org.apache.curator.x.discovery.ServiceInstance;
+
+import org.springframework.cloud.netflix.ribbon.DefaultServerIntrospector;
+
 /**
+ * {@link org.springframework.cloud.netflix.ribbon.ServerIntrospector Server introspector}
+ * implementation for Zookeeper.
+ *
  * @author Spencer Gibb
  */
 public class ZookeeperServerIntrospector extends DefaultServerIntrospector {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServerList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.curator.x.discovery.ServiceDiscovery;
-import org.apache.curator.x.discovery.ServiceInstance;
-import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
-import org.springframework.util.StringUtils;
-
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.AbstractServerList;
+import org.apache.curator.x.discovery.ServiceDiscovery;
+import org.apache.curator.x.discovery.ServiceInstance;
 
-import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
-import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_UP;
-import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
+import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
+import org.springframework.cloud.zookeeper.support.StatusConstants;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Zookeeper version of {@link AbstractServerList} that returns the list of
@@ -90,17 +88,17 @@ public class ZookeeperServerList extends AbstractServerList<ZookeeperServer> {
 			for (ServiceInstance<ZookeeperInstance> instance : instances) {
 				String instanceStatus = null;
 				if (instance.getPayload() != null && instance.getPayload().getMetadata() != null) {
-					instanceStatus = instance.getPayload().getMetadata().get(INSTANCE_STATUS_KEY);
+					instanceStatus = instance.getPayload().getMetadata().get(StatusConstants.INSTANCE_STATUS_KEY);
 				}
 				if (!StringUtils.hasText(instanceStatus) // backwards compatibility
-						|| instanceStatus.equalsIgnoreCase(STATUS_UP)) {
+						|| instanceStatus.equalsIgnoreCase(StatusConstants.STATUS_UP)) {
 					servers.add(new ZookeeperServer(instance));
 				}
 			}
 			return servers;
 		}
-		catch (Exception e) {
-			rethrowRuntimeException(e);
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 		return Collections.EMPTY_LIST;
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstance.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,9 @@ import java.util.Map;
 import org.springframework.cloud.client.ServiceInstance;
 
 /**
- * A specific {@link ServiceInstance} describing a zookeeper service instance
+ * A specific {@link ServiceInstance} describing a zookeeper service instance.
  *
- * @author Reda.Housni-Alaoui
+ * @author Reda Housni-Alaoui
  * @since 1.1.0
  */
 public class ZookeeperServiceInstance implements ServiceInstance {
@@ -38,10 +38,6 @@ public class ZookeeperServiceInstance implements ServiceInstance {
 	private final Map<String, String> metadata;
 	private final org.apache.curator.x.discovery.ServiceInstance<ZookeeperInstance> serviceInstance;
 
-	/**
-	 * @param serviceId The service id to be used
-	 * @param serviceInstance The zookeeper service instance described by this service instance
-	 */
 	public ZookeeperServiceInstance(String serviceId, org.apache.curator.x.discovery.ServiceInstance<ZookeeperInstance> serviceInstance) {
 		this.serviceId = serviceId;
 		this.serviceInstance = serviceInstance;
@@ -55,7 +51,8 @@ public class ZookeeperServiceInstance implements ServiceInstance {
 		this.uri = URI.create(serviceInstance.buildUriSpec());
 		if (serviceInstance.getPayload() != null) {
 			this.metadata = serviceInstance.getPayload().getMetadata();
-		} else {
+		}
+		else {
 			this.metadata = new HashMap<>();
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstances.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceInstances.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import java.util.ArrayList;
@@ -10,15 +26,17 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
-import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 
-import static org.springframework.cloud.zookeeper.discovery.DependencyPathUtils.sanitize;
+import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
 
 /**
  * An {@link Iterable} representing registered Zookeeper instances. If using
  * {@link ZookeeperDependencies} it will return a list of registered Zookeeper instances
  * corresponding to the ones defined in the dependencies.
  *
+ * @author Marcin Grzejszczak
+ * @author Denis Stepanov
+ * @author Spencer Gibb
  * @since 1.0.0
  */
 public class ZookeeperServiceInstances
@@ -55,9 +73,9 @@ public class ZookeeperServiceInstances
 			}
 			return allInstances;
 		}
-		catch (Exception e) {
+		catch (Exception ex) {
 			log.debug("Exception occurred while trying to build the list of instances",
-					e);
+					ex);
 			return allInstances;
 		}
 	}
@@ -74,9 +92,10 @@ public class ZookeeperServiceInstances
 		try {
 			List<String> children = this.curator.getChildren().forPath(parentPath);
 			return iterateOverChildren(accumulator, parentPath, children);
-		} catch (Exception e) {
+		}
+		catch (Exception ex) {
 			if (log.isTraceEnabled()) {
-				log.trace("Exception occurred while trying to retrieve children of [" + parentPath + "]", e);
+				log.trace("Exception occurred while trying to retrieve children of [" + parentPath + "]", ex);
 			}
 			return injectZookeeperServiceInstances(accumulator, parentPath);
 		}
@@ -93,9 +112,9 @@ public class ZookeeperServiceInstances
 			return getServiceDiscovery()
 					.queryForInstances(getPathWithoutRoot(path));
 		}
-		catch (Exception e) {
+		catch (Exception ex) {
 			log.trace("Exception occurred while trying to retrieve instances of [" + path
-					+ "]", e);
+					+ "]", ex);
 			return null;
 		}
 	}
@@ -142,7 +161,7 @@ public class ZookeeperServiceInstances
 			}
 			List<String> names = new ArrayList<>();
 			for (String name : getServiceDiscovery().queryForNames()) {
-				names.add(sanitize(name));
+				names.add(DependencyPathUtils.sanitize(name));
 			}
 			return names;
 		}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceWatch.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperServiceWatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,15 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
-import javax.annotation.PreDestroy;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.annotation.PreDestroy;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.framework.recipes.cache.TreeCacheEvent;
 import org.apache.curator.framework.recipes.cache.TreeCacheListener;
+
 import org.springframework.cloud.client.discovery.event.HeartbeatEvent;
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -69,8 +71,8 @@ public class ZookeeperServiceWatch implements
 		try {
 			this.cache.start();
 		}
-		catch (Exception e) {
-			ReflectionUtils.rethrowRuntimeException(e);
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperDiscoveryClientConfigServiceBootstrapConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperDiscoveryClientConfigServiceBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesNotPassed.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesNotPassed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Conditional;
 
 /**
- * Annotation to turn off a feature if Zookeeper dependencies have NOT been passed
+ * Annotation to turn off a feature if Zookeeper dependencies have NOT been passed.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesPassed.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ConditionalOnDependenciesPassed.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Conditional;
 
 /**
- * Annotation to turn on a feature if Zookeeper dependencies have been passed. 
+ * Annotation to turn on a feature if Zookeeper dependencies have been passed.
  * Also checks if switch for zookeeper dependencies is turned on.
  *
  * @author Marcin Grzejszczak

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesBasedLoadBalancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,12 @@ import com.netflix.loadbalancer.RandomRule;
 import com.netflix.loadbalancer.RoundRobinRule;
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
  * LoadBalancer that delegates to other rules depending on the provided load balancing strategy
- * in the {@link ZookeeperDependency#getLoadBalancerType()}
+ * in the {@link ZookeeperDependency#getLoadBalancerType()}.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
@@ -59,7 +58,8 @@ public class DependenciesBasedLoadBalancer extends DynamicServerListLoadBalancer
 		String keyAsString;
 		if ("default".equals(key)) { // this is the default hint, use name instead
 			keyAsString = getName();
-		} else {
+		}
+		else {
 			keyAsString = (String) key;
 		}
 		ZookeeperDependency dependency = this.zookeeperDependencies.getDependencyForAlias(keyAsString);

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesNotPassedCondition.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesNotPassedCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
@@ -20,7 +21,7 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
- * Inverse of the {@link ConditionalOnDependenciesPassed} condition. 
+ * Inverse of the {@link ConditionalOnDependenciesPassed} condition.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesPassedCondition.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependenciesPassedCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyEnvironmentPostProcessor.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyEnvironmentPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,11 +41,13 @@ public class DependencyEnvironmentPostProcessor
 	// after ConfigFileEnvironmentPostProcessorr
 	private int order = ConfigFileApplicationListener.DEFAULT_ORDER + 1;
 
-	@Override public int getOrder() {
+	@Override
+	public int getOrder() {
 		return this.order;
 	}
 
-	@Override public void postProcessEnvironment(ConfigurableEnvironment environment,
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment,
 			SpringApplication application) {
 		String appName = environment.getProperty("spring.application.name");
 		if (StringUtils.hasText(appName) && !appName.contains("/")) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyFeignClientAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,23 +23,23 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import feign.Client;
+import feign.Request;
+import feign.Response;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.openfeign.ribbon.CachingSpringLoadBalancerFactory;
 import org.springframework.cloud.openfeign.ribbon.FeignRibbonClientAutoConfiguration;
 import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
-import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.zookeeper.ConditionalOnZookeeperEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-
-import feign.Client;
-import feign.Request;
-import feign.Response;
 
 /**
  * Configuration for ensuring that headers are set for a given dependency when
@@ -55,10 +55,18 @@ import feign.Response;
 @ConditionalOnClass({ Client.class, LoadBalancerFeignClient.class })
 @AutoConfigureAfter({ RibbonAutoConfiguration.class, FeignRibbonClientAutoConfiguration.class })
 public class DependencyFeignClientAutoConfiguration {
-	@Autowired(required = false) private LoadBalancerFeignClient ribbonClient;
-	@Autowired private ZookeeperDependencies zookeeperDependencies;
-	@Autowired private CachingSpringLoadBalancerFactory loadBalancerFactory;
-	@Autowired private SpringClientFactory springClientFactory;
+
+	@Autowired(required = false)
+	private LoadBalancerFeignClient ribbonClient;
+
+	@Autowired
+	private ZookeeperDependencies zookeeperDependencies;
+
+	@Autowired
+	private CachingSpringLoadBalancerFactory loadBalancerFactory;
+
+	@Autowired
+	private SpringClientFactory springClientFactory;
 
 	@Bean
 	@Primary

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRestTemplateAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRestTemplateAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,8 +53,12 @@ import org.springframework.web.client.RestTemplate;
 @AutoConfigureAfter(DependencyRibbonAutoConfiguration.class)
 public class DependencyRestTemplateAutoConfiguration {
 
-	@Autowired @LoadBalanced RestTemplate restTemplate;
-	@Autowired ZookeeperDependencies zookeeperDependencies;
+	@Autowired
+	@LoadBalanced
+	RestTemplate restTemplate;
+
+	@Autowired
+	ZookeeperDependencies zookeeperDependencies;
 
 	@PostConstruct
 	void customizeRestTemplate() {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyRibbonAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
 /**
  *
  * Provides LoadBalancerClient that at runtime can pick proper load balancing strategy
- * basing on the Zookeeper dependencies from properties
+ * basing on the Zookeeper dependencies from properties.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
@@ -52,7 +52,8 @@ public class DependencyRibbonAutoConfiguration {
 
 	private static final Log log = LogFactory.getLog(DependencyRibbonAutoConfiguration.class);
 
-	@Autowired ApplicationContext applicationContext;
+	@Autowired
+	ApplicationContext applicationContext;
 
 	@Bean
 	@ConditionalOnMissingBean
@@ -62,14 +63,14 @@ public class DependencyRibbonAutoConfiguration {
 			@Override
 			protected Server getServer(String serviceId) {
 				ILoadBalancer loadBalancer = this.getLoadBalancer(serviceId);
-				return loadBalancer == null ? null : chooseServerByServiceIdOrDefault(loadBalancer, serviceId);
+				return (loadBalancer != null) ? this.chooseServerByServiceIdOrDefault(loadBalancer, serviceId) : null;
 			}
 
 			private Server chooseServerByServiceIdOrDefault(ILoadBalancer loadBalancer, String serviceId) {
 				log.debug(String.format("Dependencies are set - will try to load balance via provided load balancer [%s] for key [%s]", loadBalancer, serviceId));
 				Server server = loadBalancer.chooseServer(serviceId);
 				log.debug(String.format("Retrieved server [%s] via load balancer", server));
-				return server != null ? server : loadBalancer.chooseServer("default");
+				return (server != null) ? server : loadBalancer.chooseServer("default");
 			}
 		};
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/LoadBalancerType.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/LoadBalancerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 /**
+ * Represents all different types of load balancing.
+ *
  * @author Marcin Grzejszczak
  * @author Spencer Gibb
  * @since 1.0.0
  */
 public enum LoadBalancerType {
-	STICKY, RANDOM, ROUND_ROBIN
+	/**
+	 * Represents "sticky session" load balancing.
+	 */
+	STICKY,
+
+	/**
+	 * Represents random load balancing.
+	 */
+	RANDOM,
+
+	/**
+	 * Represents round robin load balancing.
+	 */
+	ROUND_ROBIN
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.AbstractLoadBalancerRule;
 import com.netflix.loadbalancer.IRule;
 import com.netflix.loadbalancer.Server;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StubsConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/StubsConfiguration.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.Arrays;
@@ -48,7 +64,7 @@ public class StubsConfiguration {
 		if (splitPath.length >= 2) {
 			stubsGroupId = splitPath[0];
 			stubsArtifactId = splitPath[1];
-			stubsClassifier = splitPath.length == 3 ? splitPath[2] : DEFAULT_STUBS_CLASSIFIER;
+			stubsClassifier = (splitPath.length == 3) ? splitPath[2] : DEFAULT_STUBS_CLASSIFIER;
 		}
 		return new String[]{stubsGroupId, stubsArtifactId, stubsClassifier};
 	}
@@ -74,7 +90,7 @@ public class StubsConfiguration {
 	}
 
 	public String toColonSeparatedDependencyNotation() {
-		if(!isDefined()) {
+		if (!isDefined()) {
 			return "";
 		}
 		return StringUtils.collectionToDelimitedString(Arrays.asList(getStubsGroupId(), getStubsArtifactId(), getStubsClassifier()), STUB_COLON_DELIMITER);
@@ -93,12 +109,12 @@ public class StubsConfiguration {
 	}
 
 	/**
-	 * Marker class to discern between the stubs location and dependency registration path
+	 * Marker class to discern between the stubs location and dependency registration path.
 	 */
 	static class DependencyPath {
 		private final String path;
 
-		public DependencyPath(String path) {
+		DependencyPath(String path) {
 			this.path = path;
 		}
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependencies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,22 @@
  */
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
-import javax.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cloud.zookeeper.discovery.DependencyPathUtils;
 import org.springframework.cloud.zookeeper.discovery.dependency.StubsConfiguration.DependencyPath;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.cloud.zookeeper.discovery.DependencyPathUtils.sanitize;
-
 /**
- * Representation of this service's dependencies in Zookeeper
+ * Representation of this service's dependencies in Zookeeper.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
@@ -39,18 +39,18 @@ import static org.springframework.cloud.zookeeper.discovery.DependencyPathUtils.
 public class ZookeeperDependencies {
 
 	/**
-	 * Common prefix that will be applied to all Zookeeper dependencies' paths
+	 * Common prefix that will be applied to all Zookeeper dependencies' paths.
 	 */
 	private String prefix = "";
 
 	/**
 	 * Mapping of alias to ZookeeperDependency. From Ribbon perspective the alias
-	 * is actually serviceID since Ribbon can't accept nested structures in serviceID
+	 * is actually serviceID since Ribbon can't accept nested structures in serviceID.
 	 */
 	private Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
 
 	/**
-	 * Default health endpoint that will be checked to verify that a dependency is alive
+	 * Default health endpoint that will be checked to verify that a dependency is alive.
 	 */
 	@Value("${spring.cloud.zookeeper.dependency.ribbon.loadbalancer.defaulthealthendpoint:/health}")
 	private String defaultHealthEndpoint;
@@ -58,7 +58,7 @@ public class ZookeeperDependencies {
 	@PostConstruct
 	public void init() {
 		if (StringUtils.hasText(this.prefix)) {
-			this.prefix = sanitize(this.prefix);
+			this.prefix = DependencyPathUtils.sanitize(this.prefix);
 		}
 		for (Map.Entry<String, ZookeeperDependency> entry : this.dependencies.entrySet()) {
 			ZookeeperDependency value = entry.getValue();
@@ -67,7 +67,7 @@ public class ZookeeperDependencies {
 				value.setPath(entry.getKey());
 			}
 
-			value.setPath(sanitize(value.getPath()));
+			value.setPath(DependencyPathUtils.sanitize(value.getPath()));
 
 			if (StringUtils.hasText(this.prefix)) {
 				value.setPath(this.prefix + value.getPath());
@@ -80,7 +80,8 @@ public class ZookeeperDependencies {
 	private void setStubDefinition(ZookeeperDependency value) {
 		if (!StringUtils.hasText(value.getStubs())) {
 			value.setStubsConfiguration(new StubsConfiguration(new DependencyPath(value.getPath())));
-		} else {
+		}
+		else {
 			value.setStubsConfiguration(new StubsConfiguration(value.getStubs()));
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependency.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.util.StringUtils;
-
-import static java.util.Collections.singletonList;
 
 /**
  * Represents a particular dependency of Zookeeper instance.
@@ -38,12 +37,12 @@ public class ZookeeperDependency {
 
 	/**
 	 * Path under which the dependency is registered in Zookeeper. The common prefix
-	 * {@link ZookeeperDependencies#prefix} will be applied to this path
+	 * {@link ZookeeperDependencies#prefix} will be applied to this path.
 	 */
 	private String path;
 
 	/**
-	 * Type of load balancer that should be used for this particular dependency
+	 * Type of load balancer that should be used for this particular dependency.
 	 */
 	private LoadBalancerType loadBalancerType = LoadBalancerType.ROUND_ROBIN;
 
@@ -57,19 +56,19 @@ public class ZookeeperDependency {
 
 	/**
 	 * Provide the current version number of the dependency. This version will be placed under the
-	 * {@code $version} placeholder in {@link ZookeeperDependency#contentTypeTemplate}
+	 * {@code $version} placeholder in {@link ZookeeperDependency#contentTypeTemplate}.
 	 */
 	private String version = "";
 
 	/**
-	 * You can provide a map of default headers that should be attached when sending a message to the dependency
+	 * You can provide a map of default headers that should be attached when sending a message to the dependency.
 	 */
 	private Map<String, Collection<String>> headers = new HashMap<>();
 
 	/**
-	 * If set to true - if the dependency is not present on startup then the application will not boot successfully
+	 * If set to true - if the dependency is not present on startup then the application will not boot successfully.
 	 * <p/>
-	 * {@link org.springframework.cloud.zookeeper.discovery.watcher.presence.DependencyPresenceOnStartupVerifier;}
+	 * {@link org.springframework.cloud.zookeeper.discovery.watcher.presence.DependencyPresenceOnStartupVerifier}
 	 * {@link org.springframework.cloud.zookeeper.discovery.watcher.DefaultDependencyWatcher}
 	 */
 	private boolean required;
@@ -96,7 +95,7 @@ public class ZookeeperDependency {
 	}
 
 	/**
-	 * Parsed stubs path
+	 * Parsed stubs path.
 	 */
 	private StubsConfiguration stubsConfiguration;
 
@@ -141,8 +140,9 @@ public class ZookeeperDependency {
 	private void setContentTypeFromTemplate(Map<String, Collection<String>> headers) {
 		Collection<String> contentTypes = headers.get(CONTENT_TYPE_HEADER);
 		if (contentTypes == null || contentTypes.isEmpty()) {
-			headers.put(CONTENT_TYPE_HEADER, singletonList(getContentTypeWithVersion()));
-		} else {
+			headers.put(CONTENT_TYPE_HEADER, Collections.singletonList(getContentTypeWithVersion()));
+		}
+		else {
 			contentTypes.add(getContentTypeWithVersion());
 		}
 	}
@@ -152,7 +152,8 @@ public class ZookeeperDependency {
 			Collection<String> value = newHeaders.get(entry.getKey());
 			if (value == null || value.isEmpty()) {
 				newHeaders.put(entry.getKey(), entry.getValue());
-			} else {
+			}
+			else {
 				value.addAll(entry.getValue());
 			}
 		}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DefaultDependencyWatcher.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DefaultDependencyWatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.curator.x.discovery.ServiceCache;
 import org.apache.curator.x.discovery.ServiceDiscovery;
+
 import org.springframework.cloud.client.discovery.event.InstanceRegisteredEvent;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies;
@@ -73,8 +74,8 @@ public class DefaultDependencyWatcher implements DependencyRegistrationHookProvi
 			try {
 				serviceCache.start();
 			}
-			catch (Exception e) {
-				ReflectionUtils.rethrowRuntimeException(e);
+			catch (Exception ex) {
+				ReflectionUtils.rethrowRuntimeException(ex);
 			}
 			this.dependencyPresenceOnStartupVerifier.verifyDependencyPresence(dependencyPath, serviceCache, zookeeperDependency.isRequired());
 			this.dependencyRegistry.put(dependencyPath, serviceCache);

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyRegistrationHookProvider.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyRegistrationHookProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,16 +27,16 @@ import java.io.IOException;
 public interface DependencyRegistrationHookProvider {
 
 	/**
-	 * Register hooks upon dependencies registration
+	 * Register hooks upon dependencies registration.
 	 *
-	 * @throws Exception
+	 * @throws Exception in case an error occurs while registering the dependency registration hooks
 	 */
 	void registerDependencyRegistrationHooks() throws Exception;
 
 	/**
-	 * Unregister hooks upon dependencies registration
+	 * Unregister hooks upon dependencies registration.
 	 *
-	 * @throws IOException
+	 * @throws IOException in case an error occurs while removing the dependency registration hooks
 	 */
 	void clearDependencyRegistrationHooks() throws IOException;
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyState.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyState.java
@@ -16,13 +16,19 @@
 package org.springframework.cloud.zookeeper.discovery.watcher;
 
 /**
- *
- * Represents a dependency's Zookeeper connection state
+ * Represents a dependency's Zookeeper connection state.
  *
  * @author Marcin Grzejszczak
  * @since 1.0.0
  */
 public enum DependencyState {
+	/**
+	 * Represents the 'connected' connection state.
+	 */
 	CONNECTED,
+
+	/**
+	 * Represents the 'disconnected' connection state.
+	 */
 	DISCONNECTED
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyStateChangeListenerRegistry.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyStateChangeListenerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.curator.x.discovery.ServiceCache;
 import org.apache.curator.x.discovery.details.ServiceCacheListener;
 
 /**
- * Informs all the DependencyWatcherListeners that a dependency's state has changed
+ * Informs all the DependencyWatcherListeners that a dependency's state has changed.
  *
  * @author Marcin Grzejszczak
  * @author Tomasz Nurkiewicz, 4financeIT
@@ -53,7 +53,7 @@ public class DependencyStateChangeListenerRegistry implements ServiceCacheListen
 	}
 
 	private void logCurrentState(DependencyState dependencyState) {
-		log.info("Service cache state change for '"+this.dependencyName+"' instances, current service state: " + dependencyState);
+		log.info("Service cache state change for '" + this.dependencyName + "' instances, current service state: " + dependencyState);
 	}
 
 	private void informListeners(DependencyState state) {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.curator.x.discovery.ServiceDiscovery;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherListener.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/DependencyWatcherListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ package org.springframework.cloud.zookeeper.discovery.watcher;
 public interface DependencyWatcherListener {
 
 	/**
-	 * Method executed upon state change of a dependency
+	 * Method executed upon state change of a dependency.
 	 *
 	 * @param dependencyName - alias from microservice configuration
 	 * @param newState - new state of the dependency

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DefaultDependencyPresenceOnStartupVerifier.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DefaultDependencyPresenceOnStartupVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,12 @@ package org.springframework.cloud.zookeeper.discovery.watcher.presence;
 
 /**
  * By default passes logging dependency checker in order not to shutdown the application
- * if dependency is missing
+ * if dependency is missing.
  *
  * @author Marcin Grzejszczak
- * @version 1.0.0
  *
  * @see LogMissingDependencyChecker
+ * @version 1.0.0
  */
 public class DefaultDependencyPresenceOnStartupVerifier extends DependencyPresenceOnStartupVerifier {
 	public DefaultDependencyPresenceOnStartupVerifier() {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DependencyPresenceOnStartupVerifier.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DependencyPresenceOnStartupVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import org.apache.curator.x.discovery.ServiceCache;
  *
  * @author Marcin Grzejszczak
  * @author Tomasz Szymanski, 4financeIT
- * @version 1.0.0
  *
  * @see FailOnMissingDependencyChecker
+ * @version 1.0.0
  */
 public abstract class DependencyPresenceOnStartupVerifier {
 	private static final PresenceChecker MANDATORY_DEPENDENCY_CHECKER = new FailOnMissingDependencyChecker();
@@ -42,7 +42,8 @@ public abstract class DependencyPresenceOnStartupVerifier {
 	public void verifyDependencyPresence(String dependencyName, @SuppressWarnings("rawtypes") ServiceCache serviceCache, boolean required) {
 		if (required) {
 			MANDATORY_DEPENDENCY_CHECKER.checkPresence(dependencyName, serviceCache.getInstances());
-		} else {
+		}
+		else {
 			this.optionalDependencyChecker.checkPresence(dependencyName, serviceCache.getInstances());
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/FailOnMissingDependencyChecker.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/FailOnMissingDependencyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.zookeeper.discovery.watcher.presence;
 
 import java.util.List;
@@ -20,7 +21,7 @@ import java.util.List;
 import org.apache.curator.x.discovery.ServiceInstance;
 
 /**
- * Will result in throwing an exception if there are no running instances of the dependency
+ * Will result in throwing an exception if there are no running instances of the dependency.
  *
  * @author Marcin Grzejszczak
  * @author Adam Chudzik, 4financeIT

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/LogMissingDependencyChecker.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/LogMissingDependencyChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.curator.x.discovery.ServiceInstance;
 
 /**
- * Will log the missing microservice dependency
+ * Will log the missing microservice dependency.
  *
  * @author Marcin Grzejszczak
  * @author Tomasz Dziurko, 4financeIT

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/NoInstancesRunningException.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/NoInstancesRunningException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.zookeeper.discovery.watcher.presence;
 
 /**
+ * A {@link RuntimeException} which is thrown when no instances
+ * are found for a certain service.
+ *
  * @author Marcin Grzejszczak
  * @since 1.0.0
  */

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/PresenceChecker.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/PresenceChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import org.apache.curator.x.discovery.ServiceInstance;
 public interface PresenceChecker {
 
 	/**
-	 * Checks if a given dependency is present
+	 * Checks if a given dependency is present.
 	 *
-	 * @param dependencyName
+	 * @param dependencyName the dependency name
 	 * @param serviceInstances - instances to check the dependency for
 	 */
 	void checkPresence(String dependencyName, List<ServiceInstance<?>> serviceInstances);

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ServiceInstanceRegistration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ServiceInstanceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,17 @@
 
 package org.springframework.cloud.zookeeper.serviceregistry;
 
-import org.apache.curator.x.discovery.ServiceInstance;
-import org.apache.curator.x.discovery.ServiceInstanceBuilder;
-import org.apache.curator.x.discovery.ServiceType;
-import org.apache.curator.x.discovery.UriSpec;
-import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties.DEFAULT_URI_SPEC;
+import org.apache.curator.x.discovery.ServiceInstance;
+import org.apache.curator.x.discovery.ServiceInstanceBuilder;
+import org.apache.curator.x.discovery.ServiceType;
+import org.apache.curator.x.discovery.UriSpec;
+
+import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;
+import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 
 /**
  * {@link org.springframework.cloud.client.serviceregistry.Registration} that lazily builds
@@ -36,85 +36,6 @@ import static org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryPr
  * @author Spencer Gibb
  */
 public class ServiceInstanceRegistration implements ZookeeperRegistration {
-
-	public static RegistrationBuilder builder() {
-		try {
-			return new RegistrationBuilder(ServiceInstance.<ZookeeperInstance>builder());
-		} catch (Exception e) {
-			throw new RuntimeException("Error creating ServiceInstanceBuilder", e);
-		}
-	}
-
-	public static RegistrationBuilder builder(ServiceInstanceBuilder<ZookeeperInstance> builder) {
-		return new RegistrationBuilder(builder);
-	}
-
-	public static class RegistrationBuilder {
-		protected ServiceInstanceBuilder<ZookeeperInstance> builder;
-
-		public RegistrationBuilder(ServiceInstanceBuilder<ZookeeperInstance> builder) {
-			this.builder = builder;
-		}
-
-		public ServiceInstanceRegistration build() {
-			return new ServiceInstanceRegistration(this.builder);
-		}
-
-		public RegistrationBuilder name(String name) {
-			this.builder.name(name);
-			return this;
-		}
-
-		public RegistrationBuilder address(String address) {
-			this.builder.address(address);
-			return this;
-		}
-
-		public RegistrationBuilder id(String id) {
-			this.builder.id(id);
-			return this;
-		}
-
-		public RegistrationBuilder port(int port) {
-			this.builder.port(port);
-			return this;
-		}
-
-		public RegistrationBuilder sslPort(int port) {
-			this.builder.sslPort(port);
-			return this;
-		}
-
-		public RegistrationBuilder payload(ZookeeperInstance payload) {
-			this.builder.payload(payload);
-			return this;
-		}
-
-		public RegistrationBuilder serviceType(ServiceType serviceType) {
-			this.builder.serviceType(serviceType);
-			return this;
-		}
-
-		public RegistrationBuilder registrationTimeUTC(long registrationTimeUTC) {
-			this.builder.registrationTimeUTC(registrationTimeUTC);
-			return this;
-		}
-
-		public RegistrationBuilder uriSpec(UriSpec uriSpec) {
-			this.builder.uriSpec(uriSpec);
-			return this;
-		}
-
-		public RegistrationBuilder uriSpec(String uriSpec) {
-			this.builder.uriSpec(new UriSpec(uriSpec));
-			return this;
-		}
-
-		public RegistrationBuilder defaultUriSpec() {
-			this.builder.uriSpec(new UriSpec(DEFAULT_URI_SPEC));
-			return this;
-		}
-	}
 
 	protected ServiceInstance<ZookeeperInstance> serviceInstance;
 	protected ServiceInstanceBuilder<ZookeeperInstance> builder;
@@ -184,5 +105,88 @@ public class ServiceInstanceRegistration implements ZookeeperRegistration {
 			return Collections.emptyMap();
 		}
 		return this.serviceInstance.getPayload().getMetadata();
+	}
+
+	public static RegistrationBuilder builder() {
+		try {
+			return new RegistrationBuilder(ServiceInstance.<ZookeeperInstance>builder());
+		}
+		catch (Exception ex) {
+			throw new RuntimeException("Error creating ServiceInstanceBuilder", ex);
+		}
+	}
+
+	public static RegistrationBuilder builder(ServiceInstanceBuilder<ZookeeperInstance> builder) {
+		return new RegistrationBuilder(builder);
+	}
+
+	/**
+	 * A {@link ServiceInstanceRegistration} Builder.
+	 */
+	public static class RegistrationBuilder {
+		protected ServiceInstanceBuilder<ZookeeperInstance> builder;
+
+		public RegistrationBuilder(ServiceInstanceBuilder<ZookeeperInstance> builder) {
+			this.builder = builder;
+		}
+
+		public ServiceInstanceRegistration build() {
+			return new ServiceInstanceRegistration(this.builder);
+		}
+
+		public RegistrationBuilder name(String name) {
+			this.builder.name(name);
+			return this;
+		}
+
+		public RegistrationBuilder address(String address) {
+			this.builder.address(address);
+			return this;
+		}
+
+		public RegistrationBuilder id(String id) {
+			this.builder.id(id);
+			return this;
+		}
+
+		public RegistrationBuilder port(int port) {
+			this.builder.port(port);
+			return this;
+		}
+
+		public RegistrationBuilder sslPort(int port) {
+			this.builder.sslPort(port);
+			return this;
+		}
+
+		public RegistrationBuilder payload(ZookeeperInstance payload) {
+			this.builder.payload(payload);
+			return this;
+		}
+
+		public RegistrationBuilder serviceType(ServiceType serviceType) {
+			this.builder.serviceType(serviceType);
+			return this;
+		}
+
+		public RegistrationBuilder registrationTimeUTC(long registrationTimeUTC) {
+			this.builder.registrationTimeUTC(registrationTimeUTC);
+			return this;
+		}
+
+		public RegistrationBuilder uriSpec(UriSpec uriSpec) {
+			this.builder.uriSpec(uriSpec);
+			return this;
+		}
+
+		public RegistrationBuilder uriSpec(String uriSpec) {
+			this.builder.uriSpec(new UriSpec(uriSpec));
+			return this;
+		}
+
+		public RegistrationBuilder defaultUriSpec() {
+			this.builder.uriSpec(new UriSpec(ZookeeperDiscoveryProperties.DEFAULT_URI_SPEC));
+			return this;
+		}
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper.serviceregistry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.cloud.client.serviceregistry.AbstractAutoServiceRegistration;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationProperties;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 /**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * that sets up auto-registration with Zookeeper.
+ *
  * @author Spencer Gibb
  */
 @Configuration
 @ConditionalOnMissingBean(type = "org.springframework.cloud.zookeeper.discovery.ZookeeperLifecycle")
 @ConditionalOnZookeeperDiscoveryEnabled
 @ConditionalOnProperty(value = "spring.cloud.service-registry.auto-registration.enabled", matchIfMissing = true)
-@AutoConfigureAfter( { ZookeeperServiceRegistryAutoConfiguration.class} )
-@AutoConfigureBefore( {AutoServiceRegistrationAutoConfiguration.class,ZookeeperDiscoveryAutoConfiguration.class} )
+@AutoConfigureAfter({ ZookeeperServiceRegistryAutoConfiguration.class })
+@AutoConfigureBefore({ AutoServiceRegistrationAutoConfiguration.class, ZookeeperDiscoveryAutoConfiguration.class })
 public class ZookeeperAutoServiceRegistrationAutoConfiguration {
 
 	@Bean

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperRegistration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,13 @@
 package org.springframework.cloud.zookeeper.serviceregistry;
 
 import org.apache.curator.x.discovery.ServiceInstance;
+
 import org.springframework.cloud.client.serviceregistry.Registration;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 
 /**
+ * A marker interface used by a {@link ZookeeperServiceRegistry}.
+ *
  * @author Spencer Gibb
  */
 public interface ZookeeperRegistration extends Registration {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperServiceRegistry.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperServiceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,18 @@ import java.io.IOException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
+
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.cloud.client.serviceregistry.ServiceRegistry;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
+import org.springframework.cloud.zookeeper.support.StatusConstants;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
-import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_UP;
-import static org.springframework.util.ReflectionUtils.rethrowRuntimeException;
-
 /**
+ * A Zookeeper {@link ServiceRegistry} implementation.
+ *
  * @author Spencer Gibb
  */
 public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegistration>, SmartInitializingSingleton,
@@ -65,8 +65,9 @@ public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegist
 	public void register(ZookeeperRegistration registration) {
 		try {
 			getServiceDiscovery().registerService(registration.getServiceInstance());
-		} catch (Exception e) {
-			rethrowRuntimeException(e);
+		}
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 
@@ -78,8 +79,9 @@ public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegist
 	public void deregister(ZookeeperRegistration registration) {
 		try {
 			getServiceDiscovery().unregisterService(registration.getServiceInstance());
-		} catch (Exception e) {
-			rethrowRuntimeException(e);
+		}
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 
@@ -87,8 +89,9 @@ public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegist
 	public void afterSingletonsInstantiated() {
 		try {
 			getServiceDiscovery().start();
-		} catch (Exception e) {
-			rethrowRuntimeException(e);
+		}
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 
@@ -96,8 +99,9 @@ public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegist
 	public void close() {
 		try {
 			getServiceDiscovery().close();
-		} catch (IOException e) {
-			rethrowRuntimeException(e);
+		}
+		catch (IOException ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 
@@ -105,21 +109,22 @@ public class ZookeeperServiceRegistry implements ServiceRegistry<ZookeeperRegist
 	public void setStatus(ZookeeperRegistration registration, String status) {
 		ServiceInstance<ZookeeperInstance> serviceInstance = registration.getServiceInstance();
 		ZookeeperInstance instance = serviceInstance.getPayload();
-		instance.getMetadata().put(INSTANCE_STATUS_KEY, status);
+		instance.getMetadata().put(StatusConstants.INSTANCE_STATUS_KEY, status);
 		try {
 			getServiceDiscovery().updateService(serviceInstance);
-		} catch (Exception e) {
-			ReflectionUtils.rethrowRuntimeException(e);
+		}
+		catch (Exception ex) {
+			ReflectionUtils.rethrowRuntimeException(ex);
 		}
 	}
 
 	@Override
 	public Object getStatus(ZookeeperRegistration registration) {
 		ZookeeperInstance instance = registration.getServiceInstance().getPayload();
-		String instanceStatus = instance.getMetadata().get(INSTANCE_STATUS_KEY);
+		String instanceStatus = instance.getMetadata().get(StatusConstants.INSTANCE_STATUS_KEY);
 
 		if (!StringUtils.hasText(instanceStatus)) {
-			instanceStatus = STATUS_UP;
+			instanceStatus = StatusConstants.STATUS_UP;
 		}
 		return instanceStatus;
 	}

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperServiceRegistryAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperServiceRegistryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.cloud.zookeeper.serviceregistry;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.details.InstanceSerializer;
 import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
+
 import org.springframework.beans.BeansException;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,6 +35,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * that sets up the Zookeeper service registry.
+ *
  * @author Spencer Gibb
  */
 @Configuration

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/CuratorServiceDiscoveryAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/CuratorServiceDiscoveryAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.details.InstanceSerializer;
 import org.apache.curator.x.discovery.details.JsonInstanceSerializer;
+
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.zookeeper.discovery.ConditionalOnZookeeperDiscoveryEnabled;
@@ -32,6 +33,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
+ * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto-configuration}
+ * that sets up service discovery with Zookeeper using curator.
+ *
  * @author Spencer Gibb
  */
 @Configuration

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/DefaultServiceDiscoveryCustomizer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/DefaultServiceDiscoveryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,17 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
 import org.apache.curator.x.discovery.details.InstanceSerializer;
+
 import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 
 /**
+ * Default implementation of a {@link ServiceDiscoveryCustomizer service discovery customizer}.
+ *
  * @author Spencer Gibb
  */
-public class DefaultServiceDiscoveryCustomizer implements ServiceDiscoveryCustomizer{
+public class DefaultServiceDiscoveryCustomizer implements ServiceDiscoveryCustomizer {
+
 	protected CuratorFramework curator;
 
 	protected ZookeeperDiscoveryProperties properties;

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/ServiceDiscoveryCustomizer.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/ServiceDiscoveryCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,13 @@ package org.springframework.cloud.zookeeper.support;
 
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceDiscoveryBuilder;
+
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 
 /**
+ * Interface that hooks in on the creation of
+ * a {@link org.apache.curator.x.discovery.ServiceDiscovery service discovery} instance.
+ *
  * @author Spencer Gibb
  */
 public interface ServiceDiscoveryCustomizer {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.cloud.zookeeper.support;
 
 /**
+ * Represents a list of all status constants.
+ *
  * @author Spencer Gibb
  */
 public interface StatusConstants {

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/ZookeeperServerListTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/ZookeeperServerListTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,18 +24,17 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.assertj.core.data.MapEntry;
 import org.junit.Test;
+
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperServer;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperServerList;
+import org.springframework.cloud.zookeeper.support.StatusConstants;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.cloud.zookeeper.support.StatusConstants.INSTANCE_STATUS_KEY;
-import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_OUT_OF_SERVICE;
-import static org.springframework.cloud.zookeeper.support.StatusConstants.STATUS_UP;
 
 /**
  * @author Spencer Gibb
@@ -81,7 +80,7 @@ public class ZookeeperServerListTests {
 		ZookeeperInstance payload = null;
 
 		if (instanceStatus != null) {
-			payload = new ZookeeperInstance(id, name, Collections.singletonMap(INSTANCE_STATUS_KEY, instanceStatus));
+			payload = new ZookeeperInstance(id, name, Collections.singletonMap(StatusConstants.INSTANCE_STATUS_KEY, instanceStatus));
 		}
 		String address = "instance" + instanceNum + "addr";
 		int port = 8080 + instanceNum;
@@ -93,8 +92,8 @@ public class ZookeeperServerListTests {
 	@SuppressWarnings("unchecked")
 	public void testGetServersWithInstanceStatus() throws Exception {
 		ArrayList<ServiceInstance<ZookeeperInstance>> instances = new ArrayList<>();
-		instances.add(serviceInstance(1, STATUS_UP));
-		instances.add(serviceInstance(2, STATUS_OUT_OF_SERVICE));
+		instances.add(serviceInstance(1, StatusConstants.STATUS_UP));
+		instances.add(serviceInstance(2, StatusConstants.STATUS_OUT_OF_SERVICE));
 
 		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = mock(ServiceDiscovery.class);
 		when(serviceDiscovery.queryForInstances(nullable(String.class))).thenReturn(instances);
@@ -104,6 +103,6 @@ public class ZookeeperServerListTests {
 		assertThat(servers).hasSize(1);
 
 		assertThat(servers.get(0).getInstance().getPayload().getMetadata())
-				.contains(MapEntry.entry(INSTANCE_STATUS_KEY, STATUS_UP));
+				.contains(MapEntry.entry(StatusConstants.INSTANCE_STATUS_KEY, StatusConstants.STATUS_UP));
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/TestServiceRegistrar.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/TestServiceRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import java.io.IOException;
@@ -38,8 +39,9 @@ public class TestServiceRegistrar {
 	public void start() {
 		try {
 			this.serviceDiscovery.start();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 
@@ -50,8 +52,9 @@ public class TestServiceRegistrar {
 					.port(this.serverPort)
 					.name("testInstance")
 					.build();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
+		}
+		catch (Exception ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 
@@ -69,8 +72,8 @@ public class TestServiceRegistrar {
 		try {
 			this.serviceDiscovery.close();
 		}
-		catch (IOException e) {
-			throw new RuntimeException(e);
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryAutoRegistrationFalseTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryAutoRegistrationFalseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
@@ -37,8 +39,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
@@ -46,28 +47,33 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZookeeperDiscoveryAutoRegistrationFalseTests.Config.class,
 		properties = { "spring.application.name=testzkautoregfalse", "debug=true" },
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext
 public class ZookeeperDiscoveryAutoRegistrationFalseTests {
 
-	@Autowired DiscoveryClient discoveryClient;
-	@Value("${spring.application.name}") String springAppName;
+	@Autowired
+	DiscoveryClient discoveryClient;
 
-	@Test public void discovery_client_is_zookeeper() {
+	@Value("${spring.application.name}")
+	String springAppName;
+
+	@Test
+	public void discovery_client_is_zookeeper() {
 		//given: this.discoveryClient
 		//expect:
-		then(discoveryClient).isInstanceOf(CompositeDiscoveryClient.class);
-		CompositeDiscoveryClient composite = (CompositeDiscoveryClient) discoveryClient;
+		assertThat(this.discoveryClient).isInstanceOf(CompositeDiscoveryClient.class);
+		CompositeDiscoveryClient composite = (CompositeDiscoveryClient) this.discoveryClient;
 		List<DiscoveryClient> discoveryClients = composite.getDiscoveryClients();
 		DiscoveryClient first = discoveryClients.get(0);
-		then(first).isInstanceOf(ZookeeperDiscoveryClient.class);
+		assertThat(first).isInstanceOf(ZookeeperDiscoveryClient.class);
 	}
 
-	@Test public void application_should_not_have_been_registered() {
+	@Test
+	public void application_should_not_have_been_registered() {
 		//given:
-		List<ServiceInstance> instances = this.discoveryClient.getInstances(springAppName);
+		List<ServiceInstance> instances = this.discoveryClient.getInstances(this.springAppName);
 		//expect:
-		then(instances).isEmpty();
+		assertThat(instances).isEmpty();
 	}
 
 	@Configuration
@@ -75,15 +81,16 @@ public class ZookeeperDiscoveryAutoRegistrationFalseTests {
 	@Import(CommonTestConfig.class)
 	@EnableDiscoveryClient(autoRegister = false)
 	static class Config {
-
 	}
 
 	@Controller
 	@Profile("ribbon")
 	class PingController {
 
-		@RequestMapping("/ping") String ping() {
+		@RequestMapping("/ping")
+		String ping() {
 			return "pong";
 		}
+
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryClientTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import java.util.List;
@@ -8,16 +24,17 @@ import org.junit.Test;
 
 import org.springframework.cloud.client.ServiceInstance;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.when;
 
 /**
  * @author Marcin Grzejszczak
  */
 public class ZookeeperDiscoveryClientTests {
 
-	@Test public void should_return_an_empty_list_of_services_if_service_discovery_is_null() {
+	@Test
+	public void should_return_an_empty_list_of_services_if_service_discovery_is_null() {
 		// given:
 		ServiceDiscovery<ZookeeperInstance> serviceDiscovery = mock(ServiceDiscovery.class);
 		ZookeeperDiscoveryClient zookeeperDiscoveryClient = new ZookeeperDiscoveryClient(
@@ -25,7 +42,7 @@ public class ZookeeperDiscoveryClientTests {
 		// when:
 		List<String> services = zookeeperDiscoveryClient.getServices();
 		// then:
-		then(services).isEmpty();
+		assertThat(services).isEmpty();
 	}
 
 	@Test
@@ -38,7 +55,7 @@ public class ZookeeperDiscoveryClientTests {
 		// when:
 		List<String> services = discoveryClient.getServices();
 		// then:
-		then(services).isEmpty();
+		assertThat(services).isEmpty();
 	}
 
 	@Test
@@ -51,6 +68,6 @@ public class ZookeeperDiscoveryClientTests {
 		// when:
 		List<ServiceInstance> instances = discoveryClient.getInstances("myservice");
 		// then:
-		then(instances).isEmpty();
+		assertThat(instances).isEmpty();
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryDisabledTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryDisabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,10 @@ import org.apache.curator.framework.CuratorFramework;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +35,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZookeeperDiscoveryDisabledTests.SomeApp.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = {"spring.cloud.zookeeper.discovery.enabled=false", "debug=true"})
 public class ZookeeperDiscoveryDisabledTests {
 

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicatorDisabledTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicatorDisabledTests.java
@@ -1,23 +1,40 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT,
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = "management.health.zookeeper.enabled=false")
 public class ZookeeperDiscoveryHealthIndicatorDisabledTests {
 
@@ -25,15 +42,17 @@ public class ZookeeperDiscoveryHealthIndicatorDisabledTests {
 	private ZookeeperDiscoveryHealthIndicator healthIndicator;
 
 	// Issue: #101 - ZookeeperDiscoveryHealthIndicator should be able to be disabled with a property
-	@Test public void healthIndicatorDisabled() {
+	@Test
+	public void healthIndicatorDisabled() {
 		// when:
 		// then:
-		then(this.healthIndicator).isNull();
+		assertThat(this.healthIndicator).isNull();
 	}
-	
+
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	@Import(CommonTestConfig.class)
-	static class Config {}
+	static class Config {
+	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import java.lang.invoke.MethodHandles;
@@ -10,10 +26,12 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.curator.framework.CuratorFramework;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
 import org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient;
@@ -28,9 +46,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient.BASE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -38,26 +54,30 @@ import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClien
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests.Config.class,
 		properties = "management.endpoints.web.exposure.include=*",
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("nestedstructure")
 public class ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests {
 
 	private static final Log log = LogFactory.getLog(MethodHandles.lookup().lookupClass());
 
-	@Autowired TestRibbonClient testRibbonClient;
-	@Autowired CuratorFramework curatorFramework;
+	@Autowired
+	TestRibbonClient testRibbonClient;
+
+	@Autowired
+	CuratorFramework curatorFramework;
 
 	// Issue: #54 - ZookeeperDiscoveryHealthIndicator fails on nested structure
-	@Test public void should_return_a_response_that_app_is_in_a_healthy_state_when_nested_folders_in_zookeeper_are_present()
+	@Test
+	public void should_return_a_response_that_app_is_in_a_healthy_state_when_nested_folders_in_zookeeper_are_present()
 			throws Exception {
 		// when:
-		String response = this.testRibbonClient.callService("me", BASE_PATH + "/health");
+		String response = this.testRibbonClient.callService("me", TestRibbonClient.BASE_PATH + "/health");
 		// then:
 		log.info("Received response [" + response + "]");
-		then(this.curatorFramework.getChildren().forPath("/services/me")).isNotEmpty();
-		then(this.curatorFramework.getChildren().forPath("/services/a/b/c/d/anotherservice")).isNotEmpty();
+		assertThat(this.curatorFramework.getChildren().forPath("/services/me")).isNotEmpty();
+		assertThat(this.curatorFramework.getChildren().forPath("/services/a/b/c/d/anotherservice")).isNotEmpty();
 	}
-	
+
 	@Configuration
 	@EnableAutoConfiguration
 	@Import(CommonTestConfig.class)
@@ -77,9 +97,10 @@ public class ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests {
 						.port(10)
 						.name("/a/b/c/d/anotherservice")
 						.build();
-				this.serviceRegistry.register(registration);
-			} catch (Exception e) {
-				throw new RuntimeException(e);
+				this.serviceRegistry.register(this.registration);
+			}
+			catch (Exception ex) {
+				throw new RuntimeException(ex);
 			}
 		}
 
@@ -88,7 +109,8 @@ public class ZookeeperDiscoveryHealthIndicatorWithNestedStructureTests {
 			this.serviceRegistry.deregister(this.registration);
 		}
 
-		@Bean TestRibbonClient testRibbonClient(@LoadBalanced RestTemplate restTemplate,
+		@Bean
+		TestRibbonClient testRibbonClient(@LoadBalanced RestTemplate restTemplate,
 				@Value("${spring.application.name}") String springAppName) {
 			return new TestRibbonClient(restTemplate, springAppName);
 		}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryPropertiesTest.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryPropertiesTest.java
@@ -1,37 +1,54 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
+
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.commons.util.InetUtilsProperties;
 
-import java.util.Arrays;
-
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
 public class ZookeeperDiscoveryPropertiesTest {
 
-    private String root;
+	private String root;
 
-    public ZookeeperDiscoveryPropertiesTest(String root) {
-        this.root = root;
-    }
+	public ZookeeperDiscoveryPropertiesTest(String root) {
+		this.root = root;
+	}
 
-    @Parameterized.Parameters(name = "With root {0}")
-    public static Iterable<String> rootVariations() {
-        return Arrays.asList("es", "es/","/es");
-    }
+	@Parameterized.Parameters(name = "With root {0}")
+	public static Iterable<String> rootVariations() {
+		return Arrays.asList("es", "es/", "/es");
+	}
 
-    @Test
-    public void should_escape_root() {
-        // given:
-        ZookeeperDiscoveryProperties zookeeperDiscoveryProperties = new ZookeeperDiscoveryProperties(new InetUtils(new InetUtilsProperties()));
-        // when:
-        zookeeperDiscoveryProperties.setRoot(root);
-        // then:
-        then(zookeeperDiscoveryProperties.getRoot()).isEqualTo("/es");
-    }
+	@Test
+	public void should_escape_root() {
+		// given:
+		ZookeeperDiscoveryProperties zookeeperDiscoveryProperties = new ZookeeperDiscoveryProperties(new InetUtils(new InetUtilsProperties()));
+		// when:
+		zookeeperDiscoveryProperties.setRoot(this.root);
+		// then:
+		assertThat(zookeeperDiscoveryProperties.getRoot()).isEqualTo("/es");
+	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryPropertiesTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryPropertiesTests.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,6 +55,5 @@ public class ZookeeperDiscoveryPropertiesTests {
 	@EnableAutoConfiguration
 	@Import(CommonTestConfig.class)
 	static class Config {
-
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoverySecurePortTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoverySecurePortTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package org.springframework.cloud.zookeeper.discovery;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.netflix.ribbon.ServerIntrospector;
@@ -35,8 +37,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -46,9 +47,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		properties = {
 			"feign.hystrix.enabled=false",
 			"spring.cloud.zookeeper.discovery.uriSpec={scheme}://{address}:{port}/contextPath",
-			"spring.cloud.zookeeper.discovery.instance-ssl-port=8443",
+			"spring.cloud.zookeeper.discovery.instance-ssl-port=8443"
 		},
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("ribbon")
 @DirtiesContext
 public class ZookeeperDiscoverySecurePortTests {
@@ -67,22 +68,22 @@ public class ZookeeperDiscoverySecurePortTests {
 
 	@Test
 	public void zookeeperServerIntrospectorWorks() {
-		ServerIntrospector serverIntrospector = this.clientFactory.getInstance(springAppName, ServerIntrospector.class);
-		then(serverIntrospector).isInstanceOf(ZookeeperServerIntrospector.class);
+		ServerIntrospector serverIntrospector = this.clientFactory.getInstance(this.springAppName, ServerIntrospector.class);
+		assertThat(serverIntrospector).isInstanceOf(ZookeeperServerIntrospector.class);
 
 		ZookeeperServer zookeeperServer = new ZookeeperServer(this.zookeeperRegistration.getServiceInstance());
-		then(serverIntrospector.isSecure(zookeeperServer)).isTrue();
+		assertThat(serverIntrospector.isSecure(zookeeperServer)).isTrue();
 	}
 
 	@Test
 	public void isSecureIsTrue() {
 		ServiceInstance instance = this.loadBalancerClient.choose(this.springAppName);
-		then(instance.isSecure()).isTrue();
+		assertThat(instance.isSecure()).isTrue();
 	}
 
 	@Test
 	public void shouldSetServiceInstanceSslPort() {
-		then(this.zookeeperRegistration.getServiceInstance().getSslPort()).isEqualTo(8443);
+		assertThat(this.zookeeperRegistration.getServiceInstance().getSslPort()).isEqualTo(8443);
 	}
 
 	@Configuration

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
@@ -1,13 +1,33 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery;
 
 import java.util.List;
 
+import com.jayway.awaitility.Awaitility;
+import com.toomuchcoding.jsonassert.JsonPath;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
@@ -30,12 +50,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import com.jayway.awaitility.Awaitility;
-import com.toomuchcoding.jsonassert.JsonPath;
-
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient.BASE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -47,52 +62,68 @@ import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClien
 			"spring.cloud.zookeeper.discovery.uri-spec={scheme}://{address}:{port}/contextPath",
 			"management.endpoints.web.exposure.include=*"
 		},
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("ribbon")
 @DirtiesContext
 public class ZookeeperDiscoveryTests {
 
-	@Autowired TestRibbonClient testRibbonClient;
-	@Autowired DiscoveryClient discoveryClient;
-	@Autowired ServiceInstanceRegistration serviceDiscovery;
-	@Value("${spring.application.name}") String springAppName;
-	@Autowired IdUsingFeignClient idUsingFeignClient;
-	@Autowired Registration registration;
+	@Autowired
+	TestRibbonClient testRibbonClient;
 
-	@Test public void should_find_the_app_by_its_name_via_Ribbon() {
+	@Autowired
+	DiscoveryClient discoveryClient;
+
+	@Autowired
+	ServiceInstanceRegistration serviceDiscovery;
+
+	@Value("${spring.application.name}")
+	String springAppName;
+
+	@Autowired
+	IdUsingFeignClient idUsingFeignClient;
+
+	@Autowired
+	Registration registration;
+
+	@Test
+	public void should_find_the_app_by_its_name_via_Ribbon() {
 		//expect:
-		then(registeredServiceStatusViaServiceName()).isEqualTo("UP");
+		assertThat(registeredServiceStatusViaServiceName()).isEqualTo("UP");
 	}
 
-	@Test public void should_find_a_collaborator_via_discovery_client() {
+	@Test
+	public void should_find_a_collaborator_via_discovery_client() {
 		//given:
 		List<ServiceInstance> instances = this.discoveryClient.getInstances(this.springAppName);
 		ServiceInstance instance = instances.get(0);
 		//expect:
-		then(registeredServiceStatus(instance)).isEqualTo("UP");
-		then(instance.getMetadata().get("testMetadataKey")).isEqualTo("testMetadataValue");
-		then(instance).isInstanceOf(ZookeeperServiceInstance.class);
+		assertThat(registeredServiceStatus(instance)).isEqualTo("UP");
+		assertThat(instance.getMetadata().get("testMetadataKey")).isEqualTo("testMetadataValue");
+		assertThat(instance).isInstanceOf(ZookeeperServiceInstance.class);
 		ZookeeperServiceInstance zkInstance = (ZookeeperServiceInstance) instance;
-		then(zkInstance.getServiceInstance().getId()).isEqualTo("ribbon-instance-id-123");
+		assertThat(zkInstance.getServiceInstance().getId()).isEqualTo("ribbon-instance-id-123");
 	}
 
-	@Test public void should_present_application_name_as_id_of_the_service_instance() {
+	@Test
+	public void should_present_application_name_as_id_of_the_service_instance() {
 		//given:
 		//expect:
-		then(this.springAppName).isEqualTo(this.registration.getServiceId());
+		assertThat(this.springAppName).isEqualTo(this.registration.getServiceId());
 	}
 
-	@Test public void should_service_instance_uri_match_uriSpec() {
+	@Test
+	public void should_service_instance_uri_match_uriSpec() {
 		//given:
 		//expect:
-		then(this.registration.getUri()).hasPath("/contextPath");
+		assertThat(this.registration.getUri()).hasPath("/contextPath");
 	}
 
-	@Test public void should_find_an_instance_using_feign_via_service_id() {
+	@Test
+	public void should_find_an_instance_using_feign_via_service_id() {
 		final IdUsingFeignClient idUsingFeignClient = this.idUsingFeignClient;
 		//expect:
 		Awaitility.await().until(() -> {
-			then(idUsingFeignClient.hi()).isNotEmpty();
+			assertThat(idUsingFeignClient.hi()).isNotEmpty();
 			return true;
 		});
 	}
@@ -102,15 +133,15 @@ public class ZookeeperDiscoveryTests {
 	}
 
 	private String registeredServiceStatus(ServiceInstance instance) {
-		return JsonPath.builder(this.testRibbonClient.callOnUrl(instance.getHost()+":"+instance.getPort(), BASE_PATH + "/health")).field("status").read(String.class);
+		return JsonPath.builder(this.testRibbonClient.callOnUrl(instance.getHost() + ":" + instance.getPort(), TestRibbonClient.BASE_PATH + "/health")).field("status").read(String.class);
 	}
 
-	@Test public void should_properly_find_local_instance() {
+	@Test
+	public void should_properly_find_local_instance() {
 		//expect:
-		then(this.serviceDiscovery.getServiceInstance().getAddress()).isEqualTo(this.registration.getHost());
+		assertThat(this.serviceDiscovery.getServiceInstance().getAddress()).isEqualTo(this.registration.getHost());
 	}
-	
-	
+
 	@FeignClient("ribbonApp")
 	public interface IdUsingFeignClient {
 		@RequestMapping(method = RequestMethod.GET, value = "/hi")
@@ -125,7 +156,8 @@ public class ZookeeperDiscoveryTests {
 	@RestController
 	static class Config {
 
-		@Bean TestRibbonClient testRibbonClient(@LoadBalanced RestTemplate restTemplate,
+		@Bean
+		TestRibbonClient testRibbonClient(@LoadBalanced RestTemplate restTemplate,
 				@Value("${spring.application.name}") String springAppName) {
 			return new TestRibbonClient(restTemplate, springAppName);
 		}
@@ -134,14 +166,17 @@ public class ZookeeperDiscoveryTests {
 		public String hi() {
 			return "hi";
 		}
+
 	}
 
 	@Controller
 	@Profile("ribbon")
 	class PingController {
 
-		@RequestMapping("/ping") String ping() {
+		@RequestMapping("/ping")
+		String ping() {
 			return "pong";
 		}
+
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperLifecycleRegistrationDisabledTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperLifecycleRegistrationDisabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,18 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertTrue;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
@@ -39,7 +40,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(classes = ZookeeperLifecycleRegistrationDisabledTests.TestPropsConfig.class,
 	properties = { "spring.application.name=myTestNotRegisteredService",
 		"spring.cloud.zookeeper.discovery.register=false", "spring.cloud.zookeeper.dependency.enabled=false"},
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ZookeeperLifecycleRegistrationDisabledTests {
 
 
@@ -49,11 +50,12 @@ public class ZookeeperLifecycleRegistrationDisabledTests {
 	@Test
 	public void contextLoads() {
 		List<ServiceInstance> instances = this.client.getInstances("myTestNotRegisteredService");
-		assertTrue("service was registered", instances.isEmpty());
+		assertThat(instances).isEmpty();
 	}
 
 	@Configuration
 	@EnableAutoConfiguration
 	@Import({ CommonTestConfig.class })
-	static class TestPropsConfig { }
+	static class TestPropsConfig {
+	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeprDiscoveryNonWebAppTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeprDiscoveryNonWebAppTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
 
 package org.springframework.cloud.zookeeper.discovery;
 
+import com.jayway.awaitility.Awaitility;
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
@@ -36,9 +38,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import com.jayway.awaitility.Awaitility;
-
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for gh-91, using s-c-zookeeper in a non-web app.
@@ -72,18 +72,20 @@ public class ZookeeprDiscoveryNonWebAppTests {
 
 		try (ConfigurableApplicationContext producerContext = producerApp.run(this.connectionString, "--server.port=0",
 				"--spring.application.name=hello-world", "--debug")) {
-			try (final ConfigurableApplicationContext context = clientApplication.run(this.connectionString,
+			try (ConfigurableApplicationContext context = clientApplication.run(this.connectionString,
 					"--spring.cloud.zookeeper.discovery.register=false")) {
 				Awaitility.await().until(new Runnable() {
-					@Override public void run() {
+					@Override
+					public void run() {
 						try {
 							HelloClient bean = context.getBean(HelloClient.class);
-							then(bean.discoveryClient.getServices()).isNotEmpty();
-							then(bean.discoveryClient.getInstances("hello-world")).isNotEmpty();
+							assertThat(bean.discoveryClient.getServices()).isNotEmpty();
+							assertThat(bean.discoveryClient.getInstances("hello-world")).isNotEmpty();
 							String string = bean.restTemplate.getForObject("http://hello-world/", String.class);
-							then(string).isEqualTo("foo");
-						} catch (IllegalStateException e) {
-							throw new AssertionError(e);
+							assertThat(string).isEqualTo("foo");
+						}
+						catch (IllegalStateException ise) {
+							throw new AssertionError(ise);
 						}
 					}
 				});
@@ -103,7 +105,8 @@ public class ZookeeprDiscoveryNonWebAppTests {
 		@Autowired
 		DiscoveryClient discoveryClient;
 
-		@Autowired RestTemplate restTemplate;
+		@Autowired
+		RestTemplate restTemplate;
 	}
 
 	@EnableAutoConfiguration(exclude = {JmxAutoConfiguration.class})

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/DiscoveryClientConfigServiceAutoConfigurationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/DiscoveryClientConfigServiceAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
@@ -70,14 +70,15 @@ public class DiscoveryClientConfigServiceAutoConfigurationTests {
 				"spring.cloud.zookeeper.discovery.instance-port:7001",
 				"spring.cloud.zookeeper.discovery.instance-host:foo",
 				"spring.cloud.config.discovery.service-id:configserver");
-		assertEquals( 1, this.context
-						.getBeanNamesForType(ZookeeperConfigServerAutoConfiguration.class).length);
+		assertThat(this.context.getBeanNamesForType(ZookeeperConfigServerAutoConfiguration.class).length)
+				.isEqualTo(1);
 		ZookeeperDiscoveryClient client = this.context.getParent().getBean(
 				ZookeeperDiscoveryClient.class);
 		verify(client, atLeast(2)).getInstances("configserver");
 		ConfigClientProperties locator = this.context
 				.getBean(ConfigClientProperties.class);
-		assertEquals("http://foo:7001/", locator.getUri()[0]);
+		assertThat(locator.getUri()[0])
+				.isEqualTo("http://foo:7001/");
 	}
 
 	private void setup(String... env) {

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerAutoConfigurationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author Dave Syer
@@ -48,15 +47,15 @@ public class ZookeeperConfigServerAutoConfigurationTests {
 	public void offByDefault() {
 		this.context = new AnnotationConfigApplicationContext(
 				ZookeeperConfigServerAutoConfiguration.class);
-		assertEquals(0,
-				this.context.getBeanNamesForType(ZookeeperDiscoveryProperties.class).length);
+		assertThat(this.context.getBeanNamesForType(ZookeeperDiscoveryProperties.class).length)
+				.isEqualTo(0);
 	}
 
 	@Test
 	public void onWhenRequested() {
 		setup("spring.cloud.config.server.prefix=/config");
-		assertEquals(1,
-				this.context.getBeanNamesForType(ZookeeperDiscoveryProperties.class).length);
+		assertThat(this.context.getBeanNamesForType(ZookeeperDiscoveryProperties.class).length)
+				.isEqualTo(1);
 		ZookeeperDiscoveryProperties properties = this.context.getBean(ZookeeperDiscoveryProperties.class);
 		assertThat(properties.getMetadata()).containsEntry("configPath", "/config");
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
@@ -50,16 +50,9 @@ public class DependencyConfig {
 	}
 
 	@Bean
-	PingController pingController() {
-		return new PingController(portListener());
-	}
-
-	@Bean
 	PortListener portListener() {
 		return new PortListener();
 	}
-
-
 
 	static class PortListener implements ApplicationListener<WebServerInitializedEvent> {
 

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.Collection;
@@ -19,12 +35,13 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Configuration
 @EnableAutoConfiguration
 @Import(CommonTestConfig.class)
-@EnableFeignClients(basePackageClasses = {AliasUsingFeignClient.class, IdUsingFeignClient.class})
+@EnableFeignClients(basePackageClasses = { DependencyConfig.AliasUsingFeignClient.class,
+		DependencyConfig.IdUsingFeignClient.class })
 public class DependencyConfig {
 
 	@Bean
@@ -42,62 +59,66 @@ public class DependencyConfig {
 		return new PortListener();
 	}
 
-}
 
-class PortListener implements ApplicationListener<WebServerInitializedEvent> {
 
-	private int port;
+	static class PortListener implements ApplicationListener<WebServerInitializedEvent> {
 
-	@Override
-	public void onApplicationEvent(WebServerInitializedEvent event) {
-		this.port = event.getWebServer().getPort();
+		private int port;
+
+		@Override
+		public void onApplicationEvent(WebServerInitializedEvent event) {
+			this.port = event.getWebServer().getPort();
+		}
+
+		public int getPort() {
+			return this.port;
+		}
+
 	}
 
-	public int getPort() {
-		return this.port;
+	@FeignClient("someAlias")
+	interface AliasUsingFeignClient {
+		@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
+		String getBeans();
+
+		@RequestMapping(method = RequestMethod.GET, value = "/checkHeaders")
+		String checkHeaders();
 	}
 
-}
-
-@FeignClient("someAlias")
-interface AliasUsingFeignClient {
-	@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
-	String getBeans();
-
-	@RequestMapping(method = RequestMethod.GET, value = "/checkHeaders")
-	String checkHeaders();
-}
-
-@FeignClient("nameWithoutAlias")
-interface IdUsingFeignClient {
-	@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
-	String getBeans();
-}
-
-@RestController
-class PingController {
-
-	private final PortListener portListener;
-
-	PingController(PortListener portListener) {
-		this.portListener = portListener;
+	@FeignClient("nameWithoutAlias")
+	interface IdUsingFeignClient {
+		@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
+		String getBeans();
 	}
 
-	@RequestMapping("/ping") String ping() {
-		return "pong";
+	@RestController
+	static class PingController {
+
+		private final PortListener portListener;
+
+		PingController(PortListener portListener) {
+			this.portListener = portListener;
+		}
+
+		@RequestMapping("/ping")
+		String ping() {
+			return "pong";
+		}
+
+		@RequestMapping("/port")
+		Integer port() {
+			return this.portListener.getPort();
+		}
+
+		@RequestMapping("/checkHeaders")
+		String checkHeaders(@RequestHeader("Content-Type") String contentType,
+							@RequestHeader("header1") Collection<String> header1,
+							@RequestHeader("header2") Collection<String> header2) {
+			assertThat(contentType).isEqualTo("application/vnd.newsletter.v1+json");
+			assertThat(header1).containsExactly("value1");
+			assertThat(header2).containsExactly("value2");
+			return "ok";
+		}
 	}
 
-	@RequestMapping("/port") Integer port() {
-		return this.portListener.getPort();
-	}
-
-	@RequestMapping("/checkHeaders") String checkHeaders(@RequestHeader("Content-Type") String contentType,
-														 @RequestHeader("header1")
-														 Collection<String> header1,
-														 @RequestHeader("header2") Collection<String> header2) {
-		then(contentType).isEqualTo("application/vnd.newsletter.v1+json");
-		then(header1).containsExactly("value1");
-		then(header2).containsExactly("value2");
-		return "ok";
-	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/StickyRuleTests.java
@@ -1,16 +1,37 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import com.jayway.awaitility.Awaitility;
+import com.netflix.loadbalancer.IPing;
+import com.netflix.loadbalancer.NoOpPing;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
@@ -25,26 +46,25 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.SocketUtils;
 import org.springframework.web.client.RestTemplate;
 
-import com.jayway.awaitility.Awaitility;
-import com.netflix.loadbalancer.IPing;
-import com.netflix.loadbalancer.NoOpPing;
-
 /**
  * @author Marcin Grzejszczak
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = StickyRuleTests.Config.class,
-		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("loadbalancerclient")
 public class StickyRuleTests {
 
-	@Autowired LoadBalancerClient loadBalancerClient;
-	@Autowired DiscoveryClient discoveryClient;
-	
+	@Autowired
+	LoadBalancerClient loadBalancerClient;
+
+	@Autowired
+	DiscoveryClient discoveryClient;
+
 	@Test
 	public void should_use_sticky_load_balancing_strategy_taken_from_Zookeeper_dependencies() {
 		//given:
-			System.setProperty("spring.cloud.zookeeper.dependency.ribbon.loadbalancer.checkping", "false");	
+			System.setProperty("spring.cloud.zookeeper.dependency.ribbon.loadbalancer.checkping", "false");
 		//expect:
 			thereAreTwoRegisteredServices();
 			URI uri = getUriForAlias();
@@ -53,7 +73,8 @@ public class StickyRuleTests {
 
 	private Callable<Boolean> uriMatchesTwice(final URI uri) {
 		return new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
+			@Override
+			public Boolean call() throws Exception {
 				return uriMatches() && uriMatches();
 			}
 
@@ -70,7 +91,7 @@ public class StickyRuleTests {
 
 	private URI getUriForAlias() {
 		ServiceInstance alias = this.loadBalancerClient.choose("someAlias");
-		return alias != null ? alias.getUri() : null;
+		return (alias != null) ? alias.getUri() : null;
 	}
 
 
@@ -80,17 +101,20 @@ public class StickyRuleTests {
 	static class Config {
 
 		@Bean
-		@LoadBalanced RestTemplate loadBalancedRestTemplate() {
+		@LoadBalanced
+		RestTemplate loadBalancedRestTemplate() {
 			return new RestTemplate();
 		}
 
-		@Bean(destroyMethod = "close") TestingServer testingServer() throws Exception {
+		@Bean(destroyMethod = "close")
+		TestingServer testingServer() throws Exception {
 			return new TestingServer(SocketUtils.findAvailableTcpPort());
 		}
 
-		@Bean ZookeeperProperties zookeeperProperties() throws Exception {
+		@Bean
+		ZookeeperProperties zookeeperProperties() throws Exception {
 			ZookeeperProperties zookeeperProperties = new ZookeeperProperties();
-			zookeeperProperties.setConnectString("localhost:"+ testingServer().getPort());
+			zookeeperProperties.setConnectString("localhost:" + testingServer().getPort());
 			return zookeeperProperties;
 		}
 
@@ -99,11 +123,13 @@ public class StickyRuleTests {
 			return new TestServiceRegistrar(SocketUtils.findAvailableTcpPort(), curatorFramework);
 		}
 
-		@Bean(initMethod = "start", destroyMethod = "stop") TestServiceRegistrar serviceTwo(CuratorFramework curatorFramework) {
+		@Bean(initMethod = "start", destroyMethod = "stop")
+		TestServiceRegistrar serviceTwo(CuratorFramework curatorFramework) {
 			return new TestServiceRegistrar(SocketUtils.findAvailableTcpPort(), curatorFramework);
 		}
 
-		@Bean IPing noOpPing() {
+		@Bean
+		IPing noOpPing() {
 			return new NoOpPing();
 		}
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/StubsConfigurationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/StubsConfigurationTests.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import org.junit.Test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -16,7 +32,7 @@ public class StubsConfigurationTests {
 		//when:
 		StubsConfiguration stubsConfiguration = new StubsConfiguration(path);
 		//then:
-		then(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
+		assertThat(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
 	}
 	@Test
 	public void should_return_empty_colon_separated_dependency_notation_if_invalid_path_has_been_provided() {
@@ -25,7 +41,7 @@ public class StubsConfigurationTests {
 		//when:
 		StubsConfiguration stubsConfiguration = new StubsConfiguration(path);
 		//then:
-		then(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
+		assertThat(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
 	}
 
 	@Test
@@ -35,10 +51,10 @@ public class StubsConfigurationTests {
 		//when:
 		StubsConfiguration stubsConfiguration = new StubsConfiguration(path);
 		//then:
-		then(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
-		then(stubsConfiguration.getStubsGroupId()).isEqualTo("");
-		then(stubsConfiguration.getStubsArtifactId()).isEqualTo("");
-		then(stubsConfiguration.getStubsClassifier()).isEqualTo("");
+		assertThat(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("");
+		assertThat(stubsConfiguration.getStubsGroupId()).isEqualTo("");
+		assertThat(stubsConfiguration.getStubsArtifactId()).isEqualTo("");
+		assertThat(stubsConfiguration.getStubsClassifier()).isEqualTo("");
 	}
 
 	@Test
@@ -48,10 +64,10 @@ public class StubsConfigurationTests {
 		//when:
 		StubsConfiguration stubsConfiguration = new StubsConfiguration(new StubsConfiguration.DependencyPath(path));
 		//then:
-		then(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("pl:a:stubs");
-		then(stubsConfiguration.getStubsGroupId()).isEqualTo("pl");
-		then(stubsConfiguration.getStubsArtifactId()).isEqualTo("a");
-		then(stubsConfiguration.getStubsClassifier()).isEqualTo("stubs");
+		assertThat(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("pl:a:stubs");
+		assertThat(stubsConfiguration.getStubsGroupId()).isEqualTo("pl");
+		assertThat(stubsConfiguration.getStubsArtifactId()).isEqualTo("a");
+		assertThat(stubsConfiguration.getStubsClassifier()).isEqualTo("stubs");
 	}
 
 	@Test
@@ -59,10 +75,10 @@ public class StubsConfigurationTests {
 		//when:
 		StubsConfiguration stubsConfiguration = new StubsConfiguration("pl", "a", "superstubs");
 		//then:
-		then(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("pl:a:superstubs");
-		then(stubsConfiguration.getStubsGroupId()).isEqualTo("pl");
-		then(stubsConfiguration.getStubsArtifactId()).isEqualTo("a");
-		then(stubsConfiguration.getStubsClassifier()).isEqualTo("superstubs");
+		assertThat(stubsConfiguration.toColonSeparatedDependencyNotation()).isEqualTo("pl:a:superstubs");
+		assertThat(stubsConfiguration.getStubsGroupId()).isEqualTo("pl");
+		assertThat(stubsConfiguration.getStubsArtifactId()).isEqualTo("a");
+		assertThat(stubsConfiguration.getStubsClassifier()).isEqualTo("superstubs");
 	}
-	
+
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesTest.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesTest.java
@@ -1,51 +1,67 @@
-package org.springframework.cloud.zookeeper.discovery.dependency;
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.junit.Test;
+package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZookeeperDependenciesTest {
 
-    @Test
-    public void should_properly_sanitize_dependency_path() {
-        // given:
-        Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
-        ZookeeperDependency cat = new ZookeeperDependency();
-        cat.setPath("/cats/cat");
-        dependencies.put("cat", cat);
-        ZookeeperDependency dog = new ZookeeperDependency();
-        dog.setPath("dogs/dog");
-        dependencies.put("dog", dog);
-        ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies();
-        zookeeperDependencies.setDependencies(dependencies);
-        // when:
-        zookeeperDependencies.init();
-        // then:
-        then(zookeeperDependencies.getDependencies().get("cat").getPath()).isEqualTo("/cats/cat");
-        then(zookeeperDependencies.getDependencies().get("dog").getPath()).isEqualTo("/dogs/dog");
-    }
+	@Test
+	public void should_properly_sanitize_dependency_path() {
+		// given:
+		Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
+		ZookeeperDependency cat = new ZookeeperDependency();
+		cat.setPath("/cats/cat");
+		dependencies.put("cat", cat);
+		ZookeeperDependency dog = new ZookeeperDependency();
+		dog.setPath("dogs/dog");
+		dependencies.put("dog", dog);
+		ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies();
+		zookeeperDependencies.setDependencies(dependencies);
+		// when:
+		zookeeperDependencies.init();
+		// then:
+		assertThat(zookeeperDependencies.getDependencies().get("cat").getPath()).isEqualTo("/cats/cat");
+		assertThat(zookeeperDependencies.getDependencies().get("dog").getPath()).isEqualTo("/dogs/dog");
+	}
 
-    @Test
-    public void should_properly_sanitize_dependency_path_with_prefix() {
-        // given:
-        Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
-        ZookeeperDependency cat = new ZookeeperDependency();
-        cat.setPath("/cats/cat");
-        dependencies.put("cat", cat);
-        ZookeeperDependency dog = new ZookeeperDependency();
-        dog.setPath("dogs/dog");
-        dependencies.put("dog", dog);
-        ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies();
-        zookeeperDependencies.setPrefix("animals/");
-        zookeeperDependencies.setDependencies(dependencies);
-        // when:
-        zookeeperDependencies.init();
-        // then:
-        then(zookeeperDependencies.getDependencies().get("cat").getPath()).isEqualTo("/animals/cats/cat");
-        then(zookeeperDependencies.getDependencies().get("dog").getPath()).isEqualTo("/animals/dogs/dog");
-    }
+	@Test
+	public void should_properly_sanitize_dependency_path_with_prefix() {
+		// given:
+		Map<String, ZookeeperDependency> dependencies = new LinkedHashMap<>();
+		ZookeeperDependency cat = new ZookeeperDependency();
+		cat.setPath("/cats/cat");
+		dependencies.put("cat", cat);
+		ZookeeperDependency dog = new ZookeeperDependency();
+		dog.setPath("dogs/dog");
+		dependencies.put("dog", dog);
+		ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies();
+		zookeeperDependencies.setPrefix("animals/");
+		zookeeperDependencies.setDependencies(dependencies);
+		// when:
+		zookeeperDependencies.init();
+		// then:
+		assertThat(zookeeperDependencies.getDependencies().get("cat").getPath()).isEqualTo("/animals/cats/cat");
+		assertThat(zookeeperDependencies.getDependencies().get("dog").getPath()).isEqualTo("/animals/dogs/dog");
+	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDependenciesTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.Collection;
@@ -8,7 +24,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -37,59 +53,68 @@ public class ZookeeperDependenciesTests {
 	}
 
 	ZookeeperDependencies zookeeperDependencies = new ZookeeperDependencies();
-	
+
 	@Before
 	public void setup() {
 		this.zookeeperDependencies.setDependencies(DEPENDENCIES);
 	}
 
-	@Test public void should_retrieve_dependency_dependency_for_good_path() {
+	@Test
+	public void should_retrieve_dependency_dependency_for_good_path() {
 		// expect:
-		then(this.zookeeperDependencies.getDependencyForPath("path")).isEqualTo(EXPECTED_DEPENDENCY);
+		assertThat(this.zookeeperDependencies.getDependencyForPath("path")).isEqualTo(EXPECTED_DEPENDENCY);
 	}
 
-	@Test public void should_retrieve_null_dependency_dependency_for_bad_path() {
+	@Test
+	public void should_retrieve_null_dependency_dependency_for_bad_path() {
 		// expect:
-		then(this.zookeeperDependencies.getDependencyForPath("unknownPath")).isNull();
+		assertThat(this.zookeeperDependencies.getDependencyForPath("unknownPath")).isNull();
 	}
 
-	@Test public void should_retrieve_dependency_for_good_alias() {
+	@Test
+	public void should_retrieve_dependency_for_good_alias() {
 		// expect:
-		then(this.zookeeperDependencies.getDependencyForAlias("alias")).isEqualTo(EXPECTED_DEPENDENCY);
+		assertThat(this.zookeeperDependencies.getDependencyForAlias("alias")).isEqualTo(EXPECTED_DEPENDENCY);
 	}
 
-	@Test public void should_retrieve_null_dependency_for_bad_alias() {
+	@Test
+	public void should_retrieve_null_dependency_for_bad_alias() {
 		// expect:
-		then(this.zookeeperDependencies.getDependencyForAlias("unknownAlias")).isNull();
+		assertThat(this.zookeeperDependencies.getDependencyForAlias("unknownAlias")).isNull();
 	}
 
-	@Test public void should_retrieve_alias_for_good_path() {
+	@Test
+	public void should_retrieve_alias_for_good_path() {
 		// expect:
-		then(this.zookeeperDependencies.getAliasForPath("path")).isEqualTo("alias");
+		assertThat(this.zookeeperDependencies.getAliasForPath("path")).isEqualTo("alias");
 	}
 
-	@Test public void should_retrieve_empty_alias_for_bad_path() {
+	@Test
+	public void should_retrieve_empty_alias_for_bad_path() {
 		// expect:
-		then(this.zookeeperDependencies.getAliasForPath("unkownPath")).isEmpty();
+		assertThat(this.zookeeperDependencies.getAliasForPath("unkownPath")).isEmpty();
 	}
 
-	@Test public void should_retrieve_path_for_good_alias() {
+	@Test
+	public void should_retrieve_path_for_good_alias() {
 		// expect:
-		then(this.zookeeperDependencies.getPathForAlias("alias")).isEqualTo("path");
+		assertThat(this.zookeeperDependencies.getPathForAlias("alias")).isEqualTo("path");
 	}
 
-	@Test public void should_retrieve_empty_path_for_bad_alias() {
+	@Test
+	public void should_retrieve_empty_path_for_bad_alias() {
 		// expect:
-		then(this.zookeeperDependencies.getPathForAlias("unknownAlias")).isEmpty();
+		assertThat(this.zookeeperDependencies.getPathForAlias("unknownAlias")).isEmpty();
 	}
 
-	@Test public void should_successfully_replace_version_in_content_type_template() {
+	@Test
+	public void should_successfully_replace_version_in_content_type_template() {
 		// given:
 		ZookeeperDependency zookeeperDependency = new ZookeeperDependency();
 		zookeeperDependency.setContentTypeTemplate("application/vnd.some-service.$version+json");
 		zookeeperDependency.setVersion("v1");
 		// expect:
-		then(zookeeperDependency.getContentTypeWithVersion()).isEqualTo("application/vnd.some-service.v1+json");
+		assertThat(zookeeperDependency.getContentTypeWithVersion()).isEqualTo("application/vnd.some-service.v1+json");
 	}
-	
+
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesIntegrationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesIntegrationTests.java
@@ -1,14 +1,32 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.util.List;
-import java.util.concurrent.Callable;
 
+import com.jayway.awaitility.Awaitility;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient;
@@ -18,9 +36,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient.BASE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -28,145 +44,146 @@ import static org.springframework.cloud.zookeeper.discovery.test.TestRibbonClien
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = ZookeeperDiscoveryWithDependenciesIntegrationTests.Config.class,
 		properties = {"feign.hystrix.enabled=false", "debug=true", "management.endpoints.web.exposure.include=*"},
-	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+	webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("dependencies")
 public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 
-	@Autowired TestRibbonClient testRibbonClient;
-	@Autowired DiscoveryClient discoveryClient;
-	@Autowired AliasUsingFeignClient aliasUsingFeignClient;
-	@Autowired IdUsingFeignClient idUsingFeignClient;
-	@Autowired ZookeeperDependencies zookeeperDependencies;
+	@Autowired
+	TestRibbonClient testRibbonClient;
 
-	@Test public void should_find_an_instance_via_path_when_alias_is_not_found() {
+	@Autowired
+	DiscoveryClient discoveryClient;
+
+	@Autowired
+	AliasUsingFeignClient aliasUsingFeignClient;
+
+	@Autowired
+	IdUsingFeignClient idUsingFeignClient;
+
+	@Autowired
+	ZookeeperDependencies zookeeperDependencies;
+
+	@Test
+	public void should_find_an_instance_via_path_when_alias_is_not_found() {
 		// given:
 		final DiscoveryClient discoveryClient = this.discoveryClient;
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				return !discoveryClient.getInstances("nameWithoutAlias").isEmpty();
-			}
-		});
+		Awaitility.await().until(() -> !discoveryClient.getInstances("nameWithoutAlias").isEmpty());
 	}
 
-	@Test public void should_fill_out_properly_the_stub_section_of_a_dependency() {
+	@Test
+	public void should_fill_out_properly_the_stub_section_of_a_dependency() {
 		// given:
 		StubsConfiguration stubsConfiguration = this.zookeeperDependencies.getDependencies().get("someAlias").getStubsConfiguration();
 		// expect:
-		then(stubsConfiguration.getStubsGroupId()).isEqualTo("org.springframework");
-		then(stubsConfiguration.getStubsArtifactId()).isEqualTo("foo");
-		then(stubsConfiguration.getStubsClassifier()).isEqualTo("stubs");
+		assertThat(stubsConfiguration.getStubsGroupId()).isEqualTo("org.springframework");
+		assertThat(stubsConfiguration.getStubsArtifactId()).isEqualTo("foo");
+		assertThat(stubsConfiguration.getStubsClassifier()).isEqualTo("stubs");
 	}
 
 	@Ignore //FIXME 2.0.0
-	@Test public void should_find_an_instance_using_feign_via_serviceID_when_alias_is_not_found() {
+	@Test
+	public void should_find_an_instance_using_feign_via_serviceID_when_alias_is_not_found() {
 		// given:
 		final IdUsingFeignClient idUsingFeignClient = this.idUsingFeignClient;
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				then(idUsingFeignClient.getBeans()).isNotEmpty();
-				return true;
-			}
+		Awaitility.await().until(() -> {
+			assertThat(idUsingFeignClient.getBeans()).isNotEmpty();
+			return true;
 		});
 	}
 
 	@Ignore //FIXME 2.0.0
-	@Test public void should_find_a_collaborator_via_load_balanced_rest_template_by_using_its_alias_from_dependencies() {
+	@Test
+	public void should_find_a_collaborator_via_load_balanced_rest_template_by_using_its_alias_from_dependencies() {
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				return callingServiceAtBeansEndpointIsNotEmpty();
-			}
-		});
+		Awaitility.await().until(() -> callingServiceAtBeansEndpointIsNotEmpty());
 	}
 
 	@Ignore //FIXME 2.0.0
-	@Test public void should_find_a_collaborator_using_feign_by_using_its_alias_from_dependencies() {
+	@Test
+	public void should_find_a_collaborator_using_feign_by_using_its_alias_from_dependencies() {
 		// given:
 		final AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				then(aliasUsingFeignClient.getBeans()).isNotEmpty();
-				return true;
-			}
+		Awaitility.await().until(() -> {
+			assertThat(aliasUsingFeignClient.getBeans()).isNotEmpty();
+			return true;
 		});
 	}
 
-	@Test public void should_have_headers_from_dependencies_attached_to_the_request_via_load_balanced_rest_template() {
+	@Test
+	public void should_have_headers_from_dependencies_attached_to_the_request_via_load_balanced_rest_template() {
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				callingServiceToCheckIfHeadersArePassed();
-				return true;
-			}
+		Awaitility.await().until(() -> {
+			callingServiceToCheckIfHeadersArePassed();
+			return true;
 		});
 	}
 
 	@Ignore //FIXME 2.0.0
-	@Test public void should_have_headers_from_dependencies_attached_to_the_request_via_feign() {
+	@Test
+	public void should_have_headers_from_dependencies_attached_to_the_request_via_feign() {
 		// given:
 		final AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				aliasUsingFeignClient.checkHeaders();
-				return true;
-			}
+		Awaitility.await().until(() -> {
+			aliasUsingFeignClient.checkHeaders();
+			return true;
 		});
 	}
 
-	@Test public void should_find_a_collaborator_via_discovery_client() {
+	@Test
+	public void should_find_a_collaborator_via_discovery_client() {
 		// // given:
 		final DiscoveryClient discoveryClient = this.discoveryClient;
 		List<ServiceInstance> instances = discoveryClient.getInstances("someAlias");
 		final ServiceInstance instance = instances.get(0);
 		// expect:
-		await().until(new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				return callingServiceViaUrlOnBeansEndpointIsNotEmpty(instance);
-			}
-		});
+		Awaitility.await().until(() -> callingServiceViaUrlOnBeansEndpointIsNotEmpty(instance));
 	}
 
-	@Test public void should_have_path_equal_to_prefixed_alias() {
+	@Test
+	public void should_have_path_equal_to_prefixed_alias() {
 		// given:
 		ZookeeperDependency dependency = this.zookeeperDependencies.getDependencyForAlias("aliasIsPath");
 		// expect:
-		then(dependency.getPath()).isEqualTo("/aliasIsPath");
+		assertThat(dependency.getPath()).isEqualTo("/aliasIsPath");
 	}
 
-	@Test public void should_have_prefixed_alias_equal_to_path() {
+	@Test
+	public void should_have_prefixed_alias_equal_to_path() {
 		// given:
 		ZookeeperDependency dependency = this.zookeeperDependencies.getDependencyForPath("/aliasIsPath");
 		// expect:
-		then(dependency.getPath()).isEqualTo("/aliasIsPath");
+		assertThat(dependency.getPath()).isEqualTo("/aliasIsPath");
 	}
 
-	@Test public void should_have_path_set_via_string_constructor() {
+	@Test
+	public void should_have_path_set_via_string_constructor() {
 		// given:
 		ZookeeperDependency dependency = this.zookeeperDependencies.getDependencyForAlias("anotherAlias");
 		// expect:
-		then(dependency.getPath()).isEqualTo("/myPath");
+		assertThat(dependency.getPath()).isEqualTo("/myPath");
 	}
 
 	// #138
-	@Test public void should_parse_dependency_with_path() {
+	@Test
+	public void should_parse_dependency_with_path() {
 		// given:
 		StubsConfiguration someServiceStub = this.zookeeperDependencies.getDependencyForAlias("some-service").getStubsConfiguration();
 		// expect:
-		then(someServiceStub.getStubsGroupId()).isEqualTo("io.company.department");
-		then(someServiceStub.getStubsArtifactId()).isEqualTo("some-service");
-		then(someServiceStub.getStubsClassifier()).isEqualTo("stubs");
+		assertThat(someServiceStub.getStubsGroupId()).isEqualTo("io.company.department");
+		assertThat(someServiceStub.getStubsArtifactId()).isEqualTo("some-service");
+		assertThat(someServiceStub.getStubsClassifier()).isEqualTo("stubs");
 	}
 
 	private boolean callingServiceAtBeansEndpointIsNotEmpty() {
-		return !this.testRibbonClient.callService("someAlias", BASE_PATH + "/beans").isEmpty();
+		return !this.testRibbonClient.callService("someAlias", TestRibbonClient.BASE_PATH + "/beans").isEmpty();
 	}
 
 	private boolean callingServiceViaUrlOnBeansEndpointIsNotEmpty(ServiceInstance instance) {
-		return !this.testRibbonClient.callOnUrl(instance.getHost() + ":" + instance.getPort(), BASE_PATH + "/beans").isEmpty();
+		return !this.testRibbonClient.callOnUrl(instance.getHost() + ":" + instance.getPort(), TestRibbonClient.BASE_PATH + "/beans").isEmpty();
 	}
 
 	private void callingServiceToCheckIfHeadersArePassed() {
@@ -177,5 +194,6 @@ public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 	@EnableAutoConfiguration
 	@Import(DependencyConfig.class)
 	@Profile("dependencies")
-	static class Config { }
+	static class Config {
+	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesIntegrationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDependenciesIntegrationTests.java
@@ -55,10 +55,10 @@ public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 	DiscoveryClient discoveryClient;
 
 	@Autowired
-	AliasUsingFeignClient aliasUsingFeignClient;
+	DependencyConfig.AliasUsingFeignClient aliasUsingFeignClient;
 
 	@Autowired
-	IdUsingFeignClient idUsingFeignClient;
+	DependencyConfig.IdUsingFeignClient idUsingFeignClient;
 
 	@Autowired
 	ZookeeperDependencies zookeeperDependencies;
@@ -85,7 +85,7 @@ public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 	@Test
 	public void should_find_an_instance_using_feign_via_serviceID_when_alias_is_not_found() {
 		// given:
-		final IdUsingFeignClient idUsingFeignClient = this.idUsingFeignClient;
+		final DependencyConfig.IdUsingFeignClient idUsingFeignClient = this.idUsingFeignClient;
 		// expect:
 		Awaitility.await().until(() -> {
 			assertThat(idUsingFeignClient.getBeans()).isNotEmpty();
@@ -104,7 +104,7 @@ public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 	@Test
 	public void should_find_a_collaborator_using_feign_by_using_its_alias_from_dependencies() {
 		// given:
-		final AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
+		final DependencyConfig.AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
 		// expect:
 		Awaitility.await().until(() -> {
 			assertThat(aliasUsingFeignClient.getBeans()).isNotEmpty();
@@ -125,7 +125,7 @@ public class ZookeeperDiscoveryWithDependenciesIntegrationTests {
 	@Test
 	public void should_have_headers_from_dependencies_attached_to_the_request_via_feign() {
 		// given:
-		final AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
+		final DependencyConfig.AliasUsingFeignClient aliasUsingFeignClient = this.aliasUsingFeignClient;
 		// expect:
 		Awaitility.await().until(() -> {
 			aliasUsingFeignClient.checkHeaders();

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDyingDependenciesTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/ZookeeperDiscoveryWithDyingDependenciesTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.dependency;
 
 import java.io.Closeable;
@@ -5,12 +21,13 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import com.jayway.awaitility.Awaitility;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.curator.test.TestingServer;
-import org.assertj.core.api.BDDAssertions;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.zookeeper.discovery.test.TestRibbonClient;
@@ -20,7 +37,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.util.SocketUtils;
 
-import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Marcin Grzejszczak
@@ -31,7 +48,8 @@ public class ZookeeperDiscoveryWithDyingDependenciesTests {
 	private static final Log log = LogFactory.getLog(ZookeeperDiscoveryWithDyingDependenciesTests.class);
 
 	// Issue: #45
-	@Test public void should_refresh_a_dependency_in_Ribbon_when_the_dependency_has_deregistered_and_registered_in_Zookeeper()
+	@Test
+	public void should_refresh_a_dependency_in_Ribbon_when_the_dependency_has_deregistered_and_registered_in_Zookeeper()
 			throws Exception {
 		ConfigurableApplicationContext serverContext = null;
 		ConfigurableApplicationContext clientContext = null;
@@ -41,7 +59,7 @@ public class ZookeeperDiscoveryWithDyingDependenciesTests {
 			int zookeeperPort = SocketUtils.findAvailableTcpPort();
 			testingServer = new TestingServer(zookeeperPort);
 			System.setProperty("spring.jmx.enabled", "false");
-			System.setProperty("spring.cloud.zookeeper.connectString", "127.0.0.1:"+zookeeperPort);
+			System.setProperty("spring.cloud.zookeeper.connectString", "127.0.0.1:" + zookeeperPort);
 			//and:
 			serverContext = contextWithProfile("server");
 			clientContext = contextWithProfile("client");
@@ -50,10 +68,11 @@ public class ZookeeperDiscoveryWithDyingDependenciesTests {
 			//and:
 			serverContext = restartContext(serverContext, "server");
 			//expect:
-			await().atMost(5, TimeUnit.SECONDS).until(
+			Awaitility.await().atMost(5, TimeUnit.SECONDS).until(
 					applicationHasStartedOnANewPort(clientContext, serverPortBeforeDying)
 			);
-		} finally {
+		}
+		finally {
 			//cleanup:
 			close(serverContext);
 			close(clientContext);
@@ -64,21 +83,20 @@ public class ZookeeperDiscoveryWithDyingDependenciesTests {
 	private Callable<Boolean> applicationHasStartedOnANewPort(
 			final ConfigurableApplicationContext clientContext,
 			final Integer serverPortBeforeDying) {
-		return new Callable<Boolean>() {
-			@Override public Boolean call() throws Exception {
-				try {
-					BDDAssertions.then(callServiceAtPortEndpoint(clientContext)).isNotEqualTo(serverPortBeforeDying);
-				} catch (Exception e) {
-					log.error("Exception occurred while trying to call the server", e);
-					return false;
-				}
-				return true;
+		return () -> {
+			try {
+				assertThat(callServiceAtPortEndpoint(clientContext)).isNotEqualTo(serverPortBeforeDying);
 			}
+			catch (Exception ex) {
+				log.error("Exception occurred while trying to call the server", ex);
+				return false;
+			}
+			return true;
 		};
 	}
 
 	private void close(Closeable closeable) throws IOException {
-		if(closeable != null) {
+		if (closeable != null) {
 			closeable.close();
 		}
 	}
@@ -99,5 +117,6 @@ public class ZookeeperDiscoveryWithDyingDependenciesTests {
 	@Configuration
 	@EnableAutoConfiguration
 	@Import(DependencyConfig.class)
-	static class Config { }
+	static class Config {
+	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/CommonTestConfig.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/CommonTestConfig.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.test;
 
 import org.apache.curator.test.TestingServer;
+
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.cloud.zookeeper.ZookeeperProperties;
 import org.springframework.context.annotation.Bean;
@@ -12,15 +29,18 @@ import org.springframework.web.client.RestTemplate;
 public class CommonTestConfig {
 
 	@Bean
-	@LoadBalanced RestTemplate loadBalancedRestTemplate() {
+	@LoadBalanced
+	RestTemplate loadBalancedRestTemplate() {
 		return new RestTemplate();
 	}
 
-	@Bean(destroyMethod = "close") TestingServer testingServer() throws Exception {
+	@Bean(destroyMethod = "close")
+	TestingServer testingServer() throws Exception {
 		return new TestingServer(SocketUtils.findAvailableTcpPort());
 	}
 
-	@Bean ZookeeperProperties zookeeperProperties(TestingServer testingServer) throws Exception {
+	@Bean
+	ZookeeperProperties zookeeperProperties(TestingServer testingServer) throws Exception {
 		ZookeeperProperties zookeeperProperties = new ZookeeperProperties();
 		zookeeperProperties.setConnectString("localhost:" + testingServer.getPort());
 		return zookeeperProperties;

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/TestRibbonClient.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/TestRibbonClient.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.test;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/TestServiceRestClient.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/test/TestServiceRestClient.java
@@ -1,7 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.test;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -17,7 +34,7 @@ public class TestServiceRestClient {
 	}
 
 	public <T> T callService(String alias, String endpoint, Class<T> clazz) {
-		String url = "http://" + alias +"/" + endpoint;
+		String url = "http://" + alias + "/" + endpoint;
 		log.info("Calling [" + url + "]");
 		return this.restTemplate.getForObject(url, clazz);
 	}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DefaultDependencyPresenceOnStartupVerifierTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DefaultDependencyPresenceOnStartupVerifierTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.watcher.presence;
 
 import java.util.Collections;
@@ -6,9 +22,9 @@ import org.apache.curator.x.discovery.ServiceCache;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.BDDMockito.mock;
 
 /**
  * @author Marcin Grzejszczak
@@ -17,7 +33,8 @@ public class DefaultDependencyPresenceOnStartupVerifierTests {
 
 	private static final String SERVICE_NAME = "service01";
 
-	@Test public void should_throw_exception_if_obligatory_dependencies_are_missing() {
+	@Test
+	public void should_throw_exception_if_obligatory_dependencies_are_missing() {
 		//given:
 		DefaultDependencyPresenceOnStartupVerifier dependencyVerifier = new DefaultDependencyPresenceOnStartupVerifier();
 		ServiceCache serviceCache = mock(ServiceCache.class);
@@ -26,9 +43,10 @@ public class DefaultDependencyPresenceOnStartupVerifierTests {
 		try {
 			dependencyVerifier.verifyDependencyPresence(SERVICE_NAME, serviceCache, true);
 			Assert.fail("Should throw no instances running exception");
-		} catch (Exception e) {
+		}
+		catch (Exception ex) {
 			//then:
-			then(e).isInstanceOf(NoInstancesRunningException.class);
+			assertThat(ex).isInstanceOf(NoInstancesRunningException.class);
 		}
 	}
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DependencyPresenceOnStartupVerifierTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/watcher/presence/DependencyPresenceOnStartupVerifierTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.zookeeper.discovery.watcher.presence;
 
 import java.util.Collections;
@@ -6,8 +22,8 @@ import org.apache.curator.x.discovery.ServiceCache;
 import org.junit.Test;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Marcin Grzejszczak
@@ -16,7 +32,8 @@ public class DependencyPresenceOnStartupVerifierTests {
 
 	private static final String SERVICE_NAME = "service01";
 
-	@Test public void should_check_optional_dependency_using_optional_dependency_checker() {
+	@Test
+	public void should_check_optional_dependency_using_optional_dependency_checker() {
 		//given:
 		PresenceChecker optionalDependencyChecker = mock(PresenceChecker.class);
 		DependencyPresenceOnStartupVerifier dependencyVerifier = new DependencyPresenceOnStartupVerifier(optionalDependencyChecker) {
@@ -28,5 +45,5 @@ public class DependencyPresenceOnStartupVerifierTests {
 		//then:
 		then(optionalDependencyChecker).should().checkPresence(SERVICE_NAME, serviceCache.getInstances());
 	}
-	
+
 }

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,12 @@ import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperInstance;
 import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
@@ -33,14 +35,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 /**
  * @author Spencer Gibb
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = { "spring.application.name=myTestService1-F" },
-		webEnvironment = RANDOM_PORT)
+		webEnvironment = WebEnvironment.RANDOM_PORT)
 public class ZookeeperAutoServiceRegistrationTests {
 
 	@Autowired
@@ -54,7 +55,7 @@ public class ZookeeperAutoServiceRegistrationTests {
 
 	@Test
 	public void contextLoads() throws Exception {
-		Collection<ServiceInstance<ZookeeperInstance>> instances = serviceDiscovery.queryForInstances("myTestService1-F");
+		Collection<ServiceInstance<ZookeeperInstance>> instances = this.serviceDiscovery.queryForInstances("myTestService1-F");
 		assertThat(instances).hasSize(1);
 
 		ServiceInstance<ZookeeperInstance> instance = instances.iterator().next();
@@ -77,6 +78,7 @@ public class ZookeeperAutoServiceRegistrationTests {
 	@Import({CommonTestConfig.class})
 	/*@ImportAutoConfiguration({AutoServiceRegistrationAutoConfiguration.class, ZookeeperAutoServiceRegistration.class,
 			ZookeeperServiceRegistryAutoConfiguration.class})*/
-	protected static class TestConfig { }
+	protected static class TestConfig {
+	}
 }
 

--- a/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
+++ b/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
@@ -37,6 +37,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 /**
+ * Sample application.
+ *
  * @author Spencer Gibb
  */
 @Configuration
@@ -100,6 +102,9 @@ public class SampleZookeeperApplication {
 		return this.rest.getForObject("http://" + this.appName + "/hi", String.class);
 	}
 
+	/**
+	 * Interface used to generate a Feign client.
+	 */
 	@FeignClient("testZookeeperApp")
 	interface AppClient {
 		@RequestMapping(path = "/hi", method = RequestMethod.GET)

--- a/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
+++ b/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,27 +83,27 @@ public class SampleZookeeperApplication {
 		return this.env.getProperty(prop, "Not Found");
 	}
 
-	@FeignClient("testZookeeperApp")
-	interface AppClient {
-		@RequestMapping(path = "/hi", method = RequestMethod.GET)
-		String hi();
-	}
-
 	@Autowired
 	RestTemplate rest;
 
-	public String rt() {
-		return this.rest.getForObject("http://" + this.appName + "/hi", String.class);
+	@Bean
+	@LoadBalanced
+	RestTemplate loadBalancedRestTemplate() {
+		return new RestTemplate();
 	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(SampleZookeeperApplication.class, args);
 	}
 
-	@Bean
-	@LoadBalanced
-	RestTemplate loadBalancedRestTemplate() {
-		return new RestTemplate();
+	public String rt() {
+		return this.rest.getForObject("http://" + this.appName + "/hi", String.class);
+	}
+
+	@FeignClient("testZookeeperApp")
+	interface AppClient {
+		@RequestMapping(path = "/hi", method = RequestMethod.GET)
+		String hi();
 	}
 
 }

--- a/spring-cloud-zookeeper-sample/src/test/java/org/springframework/cloud/zookeeper/sample/SampleApplicationTests.java
+++ b/spring-cloud-zookeeper-sample/src/test/java/org/springframework/cloud/zookeeper/sample/SampleApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.cloud.zookeeper.sample;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.Test;
+
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -29,18 +30,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SampleApplicationTests {
 
-	@Test public void contextLoads() throws Exception {
+	@Test
+	public void contextLoads() throws Exception {
+
 		int zkPort = SocketUtils.findAvailableTcpPort();
 		TestingServer server = new TestingServer(zkPort);
 
-		int port = SocketUtils.findAvailableTcpPort(zkPort+1);
+		int port = SocketUtils.findAvailableTcpPort(zkPort + 1);
 
 		ConfigurableApplicationContext context = new SpringApplicationBuilder(SampleZookeeperApplication.class).run(
-				"--server.port="+port,
+				"--server.port=" + port,
 				"--management.endpoints.web.exposure.include=*",
 				"--spring.cloud.zookeeper.connect-string=localhost:" + zkPort);
 
-		ResponseEntity<String> response = new TestRestTemplate().getForEntity("http://localhost:"+port+"/hi", String.class);
+		ResponseEntity<String> response = new TestRestTemplate().getForEntity("http://localhost:" + port + "/hi", String.class);
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
 		context.close();

--- a/spring-cloud-zookeeper-sample/src/test/java/org/springframework/cloud/zookeeper/sample/ZookeeperDisabledTests.java
+++ b/spring-cloud-zookeeper-sample/src/test/java/org/springframework/cloud/zookeeper/sample/ZookeeperDisabledTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,10 @@ package org.springframework.cloud.zookeeper.sample;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.cloud.zookeeper.ZookeeperAutoConfiguration;
 import org.springframework.cloud.zookeeper.config.ZookeeperConfigAutoConfiguration;
 import org.springframework.cloud.zookeeper.discovery.RibbonZookeeperAutoConfiguration;
@@ -35,10 +37,9 @@ import org.springframework.cloud.zookeeper.support.CuratorServiceDiscoveryAutoCo
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = SampleZookeeperApplication.class, webEnvironment = RANDOM_PORT,
+@SpringBootTest(classes = SampleZookeeperApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = "spring.cloud.zookeeper.enabled=false")
 public class ZookeeperDisabledTests {
 
@@ -77,7 +78,6 @@ public class ZookeeperDisabledTests {
 
 	@Autowired(required = false)
 	private CuratorServiceDiscoveryAutoConfiguration curatorServiceDiscoveryAutoConfiguration;
-
 
 	@Test
 	public void allPartsOfZookeeperDisabled() throws Exception {


### PR DESCRIPTION
This will resolve the checkstyle warnings.
However 2 still remain unresolved:
- `src/main/java/org/springframework/cloud/zookeeper/discovery/DependencyPathUtils.java:[25,1]`: HideUtilityClassConstructor - Utility classes should not have a public or default constructor.
- `src/main/java/org/springframework/cloud/zookeeper/support/StatusConstants.java:[24]`: InterfaceIsType - interfaces should describe a type and hence have methods.

Fixing these checkstyle warnings will result in breaking backwards compatibility, so the easiest way to resolve this is to add suppressions to `spring-cloud-build`.