### PR TITLE
URL Cleanup

### DIFF
--- a/1.1.x/checkstyle-checker.xml
+++ b/1.1.x/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<!-- this. in front of fields -->

--- a/1.1.x/spring-cloud-zookeeper.xml
+++ b/1.1.x/spring-cloud-zookeeper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Zookeeper</title>
 <date>2017-08-29</date>
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -109,7 +109,7 @@ public void registerThings() {
 <title>Instance Status</title>
 <simpara>Netflix Eureka supports having instances registered with the server that are <literal>OUT_OF_SERVICE</literal> and not returned as active service instances. This is very useful for behaviors such as blue/green deployments. The Curator Service Discovery recipe does not support this behavior. Taking advantage of the flexible payload has let Spring Cloud Zookeeper implement <literal>OUT_OF_SERVICE</literal> by updating some specific metadata and then filtering on that metadata in the Ribbon <literal>ZookeeperServerList</literal>. The <literal>ZookeeperServerList</literal> filters out all non-null instance statuses that do not equal <literal>UP</literal>. If the instance status field is empty, it is considered <literal>UP</literal> for backwards compatibility. To change the status of an instance POST <literal>OUT_OF_SERVICE</literal> to the <literal>ServiceRegistry</literal> instance status actuator endpoint.</simpara>
 <literallayout class="monospaced">----
-$ echo -n OUT_OF_SERVICE | http POST http://localhost:8081/service-registry/instance-status
+$ echo -n OUT_OF_SERVICE | http POST https://localhost:8081/service-registry/instance-status
 ----</literallayout>
 <literallayout class="monospaced">NOTE: The above example uses the `http` command from https://httpie.org</literallayout>
 </section>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/1.2.x/spring-cloud-zookeeper.xml
+++ b/1.2.x/spring-cloud-zookeeper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Zookeeper</title>
 <date>2019-03-25</date>
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -109,7 +109,7 @@ public void registerThings() {
 <title>Instance Status</title>
 <simpara>Netflix Eureka supports having instances registered with the server that are <literal>OUT_OF_SERVICE</literal> and not returned as active service instances. This is very useful for behaviors such as blue/green deployments. The Curator Service Discovery recipe does not support this behavior. Taking advantage of the flexible payload has let Spring Cloud Zookeeper implement <literal>OUT_OF_SERVICE</literal> by updating some specific metadata and then filtering on that metadata in the Ribbon <literal>ZookeeperServerList</literal>. The <literal>ZookeeperServerList</literal> filters out all non-null instance statuses that do not equal <literal>UP</literal>. If the instance status field is empty, it is considered <literal>UP</literal> for backwards compatibility. To change the status of an instance POST <literal>OUT_OF_SERVICE</literal> to the <literal>ServiceRegistry</literal> instance status actuator endpoint.</simpara>
 <literallayout class="monospaced">----
-$ echo -n OUT_OF_SERVICE | http POST http://localhost:8081/service-registry/instance-status
+$ echo -n OUT_OF_SERVICE | http POST https://localhost:8081/service-registry/instance-status
 ----</literallayout>
 <literallayout class="monospaced">NOTE: The above example uses the `http` command from https://httpie.org</literallayout>
 </section>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/2.0.x/checkstyle-checker.xml
+++ b/2.0.x/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<!-- this. in front of fields -->

--- a/2.0.x/spring-cloud-zookeeper.xml
+++ b/2.0.x/spring-cloud-zookeeper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Zookeeper</title>
 <date>2017-11-28</date>
@@ -18,11 +18,11 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>Please see the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
+<simpara>Please see the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation documentation</link> for instructions on how to install Zookeeper.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-discovery">
 <title>Service Discovery with Zookeeper</title>
-<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="http://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
+<simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. <link xl:href="https://curator.apache.org">Curator</link>(A java library for Zookeeper) provides Service Discovery services via <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery Extension</link>. Spring Cloud Zookeeper leverages this extension for service registration and discovery.</simpara>
 <section xml:id="_how_to_activate">
 <title>How to activate</title>
 <simpara>Including a dependency on <literal>org.springframework.cloud:spring-cloud-starter-zookeeper-discovery</literal> will enable auto-configuration that will setup Spring Cloud Zookeeper Discovery.</simpara>
@@ -109,7 +109,7 @@ public void registerThings() {
 <title>Instance Status</title>
 <simpara>Netflix Eureka supports having instances registered with the server that are <literal>OUT_OF_SERVICE</literal> and not returned as active service instances. This is very useful for behaviors such as blue/green deployments. The Curator Service Discovery recipe does not support this behavior. Taking advantage of the flexible payload has let Spring Cloud Zookeeper implement <literal>OUT_OF_SERVICE</literal> by updating some specific metadata and then filtering on that metadata in the Ribbon <literal>ZookeeperServerList</literal>. The <literal>ZookeeperServerList</literal> filters out all non-null instance statuses that do not equal <literal>UP</literal>. If the instance status field is empty, it is considered <literal>UP</literal> for backwards compatibility. To change the status of an instance POST <literal>OUT_OF_SERVICE</literal> to the <literal>ServiceRegistry</literal> instance status actuator endpoint.</simpara>
 <literallayout class="monospaced">----
-$ echo -n OUT_OF_SERVICE | http POST http://localhost:8081/service-registry/instance-status
+$ echo -n OUT_OF_SERVICE | http POST https://localhost:8081/service-registry/instance-status
 ----</literallayout>
 <literallayout class="monospaced">NOTE: The above example uses the `http` command from https://httpie.org</literallayout>
 </section>
@@ -318,7 +318,7 @@ of your dependencies.</simpara>
 </chapter>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
-<simpara>Zookeeper provides a <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
+<simpara>Zookeeper provides a <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link> that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the <literal>/config</literal> namespace by default.  Multiple <literal>PropertySource</literal> instances are created based on the application&#8217;s name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:</simpara>
 <screen>config/testApp,dev
 config/testApp
 config/application,dev

--- a/checkstyle-checker.xml
+++ b/checkstyle-checker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
 	<module name="TreeWalker">
 		<!-- this. in front of fields -->

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
-<svg xmlns="http://www.w3.org/2000/svg">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="https://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>
 <font id="fontawesomeregular" horiz-adv-x="1536" >

--- a/spring-cloud-zookeeper.xml
+++ b/spring-cloud-zookeeper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?asciidoc-toc?>
 <?asciidoc-numbered?>
-<book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
+<book xmlns="https://docbook.org/ns/docbook" xmlns:xl="https://www.w3.org/1999/xlink" version="5.0" xml:lang="en">
 <info>
 <title>Spring Cloud Zookeeper</title>
 <date>2019-03-08</date>
@@ -18,7 +18,7 @@ with Spring Cloud Netflix provides Intelligent Routing (Zuul), Client Side Load 
 </preface>
 <chapter xml:id="spring-cloud-zookeeper-install">
 <title>Install Zookeeper</title>
-<simpara>See the <link xl:href="http://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
+<simpara>See the <link xl:href="https://zookeeper.apache.org/doc/current/zookeeperStarted.html">installation
 documentation</link> for instructions on how to install Zookeeper.</simpara>
 <simpara>Spring Cloud Zookeeper uses Apache Curator behind the scenes.
 While Zookeeper 3.5.x is still considered "beta" by the Zookeeper development team,
@@ -71,8 +71,8 @@ compile('org.apache.zookeeper:zookeeper:3.4.12') {
 <title>Service Discovery with Zookeeper</title>
 <simpara>Service Discovery is one of the key tenets of a microservice based architecture. Trying to
 hand-configure each client or some form of convention can be difficult to do and can be
-brittle. <link xl:href="http://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
-Discovery through a <link xl:href="http://curator.apache.org/curator-x-discovery/">Service Discovery
+brittle. <link xl:href="https://curator.apache.org">Curator</link>(A Java library for Zookeeper) provides Service
+Discovery through a <link xl:href="https://curator.apache.org/curator-x-discovery/">Service Discovery
 Extension</link>. Spring Cloud Zookeeper uses this extension for service registration and
 discovery.</simpara>
 <section xml:id="_activating">
@@ -200,7 +200,7 @@ filters out all non-null instance statuses that do not equal <literal>UP</litera
 field is empty, it is considered to be <literal>UP</literal> for backwards compatibility. To change the
 status of an instance, make a <literal>POST</literal> with <literal>OUT_OF_SERVICE</literal> to the <literal>ServiceRegistry</literal>
 instance status actuator endpoint, as shown in the following example:</simpara>
-<programlisting language="sh" linenumbering="unnumbered">$ http POST http://localhost:8081/service-registry status=OUT_OF_SERVICE</programlisting>
+<programlisting language="sh" linenumbering="unnumbered">$ http POST https://localhost:8081/service-registry status=OUT_OF_SERVICE</programlisting>
 <note>
 <simpara>The preceding example uses the <literal>http</literal> command from <link xl:href="https://httpie.org">https://httpie.org</link>.</simpara>
 </note>
@@ -464,7 +464,7 @@ overridden.</simpara>
 <chapter xml:id="spring-cloud-zookeeper-config">
 <title>Distributed Configuration with Zookeeper</title>
 <simpara>Zookeeper provides a
-<link xl:href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
+<link xl:href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</link>
 that lets clients store arbitrary data, such as configuration data. Spring Cloud Zookeeper
 Config is an alternative to the
 <link xl:href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</link>.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://localhost:8081/service-registry (AnnotatedConnectException) with 1 occurrences migrated to:  
  https://localhost:8081/service-registry ([https](https://localhost:8081/service-registry) result AnnotatedConnectException).
* [ ] http://localhost:8081/service-registry/instance-status (AnnotatedConnectException) with 3 occurrences migrated to:  
  https://localhost:8081/service-registry/instance-status ([https](https://localhost:8081/service-registry/instance-status) result AnnotatedConnectException).
* [ ] http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 3 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://curator.apache.org with 4 occurrences migrated to:  
  https://curator.apache.org ([https](https://curator.apache.org) result 200).
* [ ] http://curator.apache.org/curator-x-discovery/ with 4 occurrences migrated to:  
  https://curator.apache.org/curator-x-discovery/ ([https](https://curator.apache.org/curator-x-discovery/) result 200).
* [ ] http://docbook.org/ns/docbook with 4 occurrences migrated to:  
  https://docbook.org/ns/docbook ([https](https://docbook.org/ns/docbook) result 200).
* [ ] http://www.w3.org/1999/xlink with 4 occurrences migrated to:  
  https://www.w3.org/1999/xlink ([https](https://www.w3.org/1999/xlink) result 200).
* [ ] http://www.w3.org/2000/svg with 1 occurrences migrated to:  
  https://www.w3.org/2000/svg ([https](https://www.w3.org/2000/svg) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperOver.html with 4 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperOver.html ([https](https://zookeeper.apache.org/doc/current/zookeeperOver.html) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperStarted.html with 4 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperStarted.html ([https](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) result 200).