### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ Intelligent Routing (Zuul) and Client Side Load Balancing (Ribbon), Circuit Brea
 
 "ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."
 
-See the http://zookeeper.apache.org[Zookeeper site] for more information.  Spring Cloud Zookeeper also builds on the http://curator.apache.org[Apache Curator] project which started life at Netflix.
+See the https://zookeeper.apache.org[Zookeeper site] for more information.  Spring Cloud Zookeeper also builds on the https://curator.apache.org[Apache Curator] project which started life at Netflix.
 
 == Spring Cloud Zookeeper Features
 
@@ -25,9 +25,9 @@ See the http://zookeeper.apache.org[Zookeeper site] for more information.  Sprin
 
 == Running the sample
 
-1. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_Download[Install zookeeper] (On a mac with homebrew `brew install zookeeper`).
-2. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode[Start zookeeper].
-3. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_ConnectingToZooKeeper[Verify zookeeper is running].
+1. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_Download[Install zookeeper] (On a mac with homebrew `brew install zookeeper`).
+2. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode[Start zookeeper].
+3. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_ConnectingToZooKeeper[Verify zookeeper is running].
 4. Run `mvn --settings .settings.xml package` this will bring in the required spring cloud maven repositories and build
 5. Run `java -jar spring-cloud-zookeeper-sample/target/spring-cloud-zookeeper-sample-1.0.5.BUILD-SNAPSHOT.jar`
 6. Visit http://localhost:8080, verify that `{"serviceId":"testZookeeperApp","host":"<yourhost>","port":8080}` results
@@ -71,7 +71,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -93,13 +93,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -155,7 +155,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -168,6 +168,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -6,7 +6,7 @@ include::intro.adoc[]
 
 "ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services."
 
-See the http://zookeeper.apache.org[Zookeeper site] for more information.  Spring Cloud Zookeeper also builds on the http://curator.apache.org[Apache Curator] project which started life at Netflix.
+See the https://zookeeper.apache.org[Zookeeper site] for more information.  Spring Cloud Zookeeper also builds on the https://curator.apache.org[Apache Curator] project which started life at Netflix.
 
 == Spring Cloud Zookeeper Features
 
@@ -16,9 +16,9 @@ See the http://zookeeper.apache.org[Zookeeper site] for more information.  Sprin
 
 == Running the sample
 
-1. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_Download[Install zookeeper] (On a mac with homebrew `brew install zookeeper`).
-2. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode[Start zookeeper].
-3. http://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_ConnectingToZooKeeper[Verify zookeeper is running].
+1. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_Download[Install zookeeper] (On a mac with homebrew `brew install zookeeper`).
+2. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_InstallingSingleMode[Start zookeeper].
+3. https://zookeeper.apache.org/doc/current/zookeeperStarted.html#sc_ConnectingToZooKeeper[Verify zookeeper is running].
 4. Run `mvn --settings .settings.xml package` this will bring in the required spring cloud maven repositories and build
 5. Run `java -jar spring-cloud-zookeeper-sample/target/spring-cloud-zookeeper-sample-1.0.5.BUILD-SNAPSHOT.jar`
 6. Visit http://localhost:8080, verify that `{"serviceId":"testZookeeperApp","host":"<yourhost>","port":8080}` results

--- a/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-zookeeper
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :toc: left
 :nofooter:
 
@@ -11,12 +11,12 @@ include::intro.adoc[]
 
 [[spring-cloud-zookeeper-install]]
 == Install Zookeeper
-Please see the http://zookeeper.apache.org/doc/current/zookeeperStarted.html[installation documentation] for instructions on how to install Zookeeper.
+Please see the https://zookeeper.apache.org/doc/current/zookeeperStarted.html[installation documentation] for instructions on how to install Zookeeper.
 
 [[spring-cloud-zookeeper-discovery]]
 == Service Discovery with Zookeeper
 
-Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. http://curator.apache.org[Curator](A java library for Zookeeper) provides Service Discovery services via http://curator.apache.org/curator-x-discovery/[Service Discovery Extension]. Spring Cloud Zookeeper leverages this extension for service registration and discovery.
+Service Discovery is one of the key tenets of a microservice based architecture. Trying to hand configure each client or some form of convention can be very difficult to do and can be very brittle. https://curator.apache.org[Curator](A java library for Zookeeper) provides Service Discovery services via https://curator.apache.org/curator-x-discovery/[Service Discovery Extension]. Spring Cloud Zookeeper leverages this extension for service registration and discovery.
 
 === How to activate
 
@@ -298,7 +298,7 @@ The functionality can be overriden since the `DefaultDependencyPresenceOnStartup
 
 == Distributed Configuration with Zookeeper
 
-Zookeeper provides a http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace[hierarchical namespace] that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the https://github.com/spring-cloud/spring-cloud-config[Config Server and Client].  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the `/config` namespace by default.  Multiple `PropertySource` instances are created based on the application's name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:
+Zookeeper provides a https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace[hierarchical namespace] that allows clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the https://github.com/spring-cloud/spring-cloud-config[Config Server and Client].  Configuration is loaded into the Spring Environment during the special "bootstrap" phase.  Configuration is stored in the `/config` namespace by default.  Multiple `PropertySource` instances are created based on the application's name and the active profiles that mimicks the Spring Cloud Config order of resolving properties.  For example, an application with the name "testApp" and with the "dev" profile will have the following property sources created:
 
 ----
 config/testApp,dev

--- a/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocator.java
+++ b/spring-cloud-zookeeper-config/src/main/java/org/springframework/cloud/zookeeper/config/ZookeeperPropertySourceLocator.java
@@ -30,7 +30,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
 
 /**
- * Zookeeper provides a <a href="http://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</a> that allows
+ * Zookeeper provides a <a href="https://zookeeper.apache.org/doc/current/zookeeperOver.html#sc_dataModelNameSpace">hierarchical namespace</a> that allows
  * clients to store arbitrary data, such as configuration data.  Spring Cloud Zookeeper Config is an alternative to the
  * <a href="https://github.com/spring-cloud/spring-cloud-config">Config Server and Client</a>.  Configuration is loaded into the Spring Environment during
  * the special "bootstrap" phase.  Configuration is stored in the {@code /config} namespace by default.  Multiple


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://curator.apache.org with 3 occurrences migrated to:  
  https://curator.apache.org ([https](https://curator.apache.org) result 200).
* [ ] http://curator.apache.org/curator-x-discovery/ with 1 occurrences migrated to:  
  https://curator.apache.org/curator-x-discovery/ ([https](https://curator.apache.org/curator-x-discovery/) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://zookeeper.apache.org with 2 occurrences migrated to:  
  https://zookeeper.apache.org ([https](https://zookeeper.apache.org) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperOver.html with 2 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperOver.html ([https](https://zookeeper.apache.org/doc/current/zookeeperOver.html) result 200).
* [ ] http://zookeeper.apache.org/doc/current/zookeeperStarted.html with 7 occurrences migrated to:  
  https://zookeeper.apache.org/doc/current/zookeeperStarted.html ([https](https://zookeeper.apache.org/doc/current/zookeeperStarted.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://hello-world/ with 1 occurrences
* http://localhost:8080 with 4 occurrences