### PR TITLE
Add spring-boot-configuration-processor to spring-cloud-zookeeper-config

### DIFF
--- a/spring-cloud-zookeeper-config/pom.xml
+++ b/spring-cloud-zookeeper-config/pom.xml
@@ -61,6 +61,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
Add `spring-boot-configuration-processor` to `spring-cloud-zookeeper-config` to address:
* spring-cloud/spring-cloud-zookeeper#174
* spring-cloud/spring-cloud-zookeeper#272