### PR TITLE
Adding support for automatic instance status publishing - fixes gh-266

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-zookeeper.adoc
@@ -218,6 +218,14 @@ $ http POST http://localhost:8081/service-registry status=OUT_OF_SERVICE
 
 NOTE: The preceding example uses the `http` command from https://httpie.org.
 
+==== Automatic Instance Status publishing
+Spring Cloud Zookeeper supports the automatic publishing of the instance status to the service registry. This can explicitly be enabled using the property `spring.cloud.zookeeper.discovery.publishInstanceHealthStatus`. You can set the automatic instance publishing interval via `spring.cloud.discovery.instanceHealthStatusPublishInterval` in milliseconds the default value is 10000 (10 seconds).
+
+The instance status is determined from the actuator `HealthEndpoint`. Therfore every custom `HealthContributor` is being respected.
+
+NOTE: For the automatic instance status publishing to work you must include the Spring Boot Actuator dependency. Furthermore `@EnableScheduling` must be present on one of your Configuration classes.
+
+
 [[spring-cloud-zookeeper-dependencies]]
 == Zookeeper Dependencies
 

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryProperties.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.zookeeper.discovery;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.commons.util.InetUtils;
 import org.springframework.cloud.zookeeper.support.StatusConstants;
@@ -98,6 +99,18 @@ public class ZookeeperDiscoveryProperties {
 	 * {@link StatusConstants#STATUS_UP}).
 	 */
 	private String initialStatus = StatusConstants.STATUS_UP;
+
+	/**
+	 * Publish the instance health status based on {@link HealthEndpoint} to the service
+	 * registry.
+	 */
+	private boolean publishInstanceHealthStatus = false;
+
+	/**
+	 * Interval in milliseconds in which the instance health status is checked and
+	 * published.
+	 */
+	private long instanceHealthStatusPublishInterval = 10000;
 
 	/**
 	 * Order of the discovery client used by `CompositeDiscoveryClient` for sorting
@@ -206,6 +219,23 @@ public class ZookeeperDiscoveryProperties {
 
 	public void setInitialStatus(String initialStatus) {
 		this.initialStatus = initialStatus;
+	}
+
+	public boolean isPublishInstanceHealthStatus() {
+		return publishInstanceHealthStatus;
+	}
+
+	public void setPublishInstanceHealthStatus(boolean publishInstanceHealthStatus) {
+		this.publishInstanceHealthStatus = publishInstanceHealthStatus;
+	}
+
+	public long getInstanceHealthStatusPublishInterval() {
+		return instanceHealthStatusPublishInterval;
+	}
+
+	public void setInstanceHealthStatusPublishInterval(
+			long instanceHealthStatusPublishInterval) {
+		this.instanceHealthStatusPublishInterval = instanceHealthStatusPublishInterval;
 	}
 
 	public int getOrder() {

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationAutoConfiguration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperAutoServiceRegistrationAutoConfiguration.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.zookeeper.serviceregistry;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.client.serviceregistry.AutoServiceRegistrationAutoConfiguration;
@@ -30,6 +33,7 @@ import org.springframework.cloud.zookeeper.support.StatusConstants;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.util.StringUtils;
 
 /**
@@ -80,6 +84,18 @@ public class ZookeeperAutoServiceRegistrationAutoConfiguration {
 		// TODO add customizer?
 
 		return builder.build();
+	}
+
+	@Bean
+	@ConditionalOnAvailableEndpoint(endpoint = HealthEndpoint.class)
+	@ConditionalOnProperty(name = "spring.cloud.zookeeper.discovery.publishInstanceHealthStatus", havingValue = "true")
+	@ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
+	public ZookeeperInstanceHealthPublisher zookeeperInstanceHealthPublisher(
+			HealthEndpoint healthEndpoint,
+			ZookeeperServiceRegistry zookeeperServiceRegistry,
+			ZookeeperRegistration zookeeperRegistration) {
+		return new ZookeeperInstanceHealthPublisher(healthEndpoint,
+				zookeeperServiceRegistry, zookeeperRegistration);
 	}
 
 }

--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperInstanceHealthPublisher.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ZookeeperInstanceHealthPublisher.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.serviceregistry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * The {@link ZookeeperInstanceHealthPublisher} is responsible for automatically updating
+ * the instance status using the {@link HealthEndpoint}. Therefore it uses the
+ * {@linkplain TaskScheduler} to schedule the instance status updates.*
+ * @author Jan Thewes
+ */
+public class ZookeeperInstanceHealthPublisher {
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(ZookeeperInstanceHealthPublisher.class);
+	private final HealthEndpoint healthEndpoint;
+	private final ZookeeperServiceRegistry zookeeperServiceRegistry;
+	private final ZookeeperRegistration zookeeperRegistration;
+
+	public ZookeeperInstanceHealthPublisher(HealthEndpoint healthEndpoint,
+			ZookeeperServiceRegistry zookeeperServiceRegistry,
+			ZookeeperRegistration zookeeperRegistration) {
+		if (logger.isTraceEnabled()) {
+			logger.trace("Instance health publisher is activated");
+		}
+		this.healthEndpoint = healthEndpoint;
+		this.zookeeperServiceRegistry = zookeeperServiceRegistry;
+		this.zookeeperRegistration = zookeeperRegistration;
+	}
+
+	@Scheduled(initialDelayString = "${spring.cloud.zookeeper.discovery"
+			+ ".instanceHealthStatusPublishInterval}", fixedDelayString = "${spring.cloud.zookeeper.discovery"
+					+ ".instanceHealthStatusPublishInterval}")
+	public void executeHealthStatusPublish() {
+		try {
+			logger.trace("Checking instance health status");
+			String currentRegisteredInstanceStatus = zookeeperServiceRegistry
+					.getStatus(zookeeperRegistration).toString();
+			String currentInstanceStatus = healthEndpoint.health().getStatus().getCode();
+			if (currentRegisteredInstanceStatus == null
+					|| !currentRegisteredInstanceStatus.equals(currentInstanceStatus)) {
+				if (logger.isTraceEnabled()) {
+					logger.trace(
+							"Setting instance status to '{}'. Current status in service registry is '{}'",
+							currentInstanceStatus, currentRegisteredInstanceStatus);
+				}
+				zookeeperServiceRegistry.setStatus(zookeeperRegistration,
+						currentInstanceStatus);
+			}
+		}
+		catch (Exception e) {
+			logger.warn(
+					"There was an error publishing the current health status to the service registry",
+					e);
+		}
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthPublishingTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryHealthPublishingTests.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.discovery;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.zookeeper.discovery.test.CommonTestConfig;
+import org.springframework.cloud.zookeeper.serviceregistry.ZookeeperRegistration;
+import org.springframework.cloud.zookeeper.serviceregistry.ZookeeperServiceRegistry;
+import org.springframework.cloud.zookeeper.test.ZookeeperTestingServer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Jan Thewes
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = ZookeeperDiscoveryHealthPublishingTests.Config.class, webEnvironment = RANDOM_PORT)
+@ContextConfiguration(loader = ZookeeperTestingServer.Loader.class)
+@ActiveProfiles("instancestatuspublishing")
+@DirtiesContext
+public class ZookeeperDiscoveryHealthPublishingTests {
+
+	@Autowired
+	ZookeeperRegistration zookeeperRegistration;
+	@Autowired
+	ZookeeperServiceRegistry zookeeperServiceRegistry;
+	@Value("${spring.application.name}")
+	String springAppName;
+	@Autowired
+	ModifyableHealthContributor modifyableHealthContributor;
+
+	@Test
+	public void check_instance_status_is_up_after_start() {
+		then(zookeeperServiceRegistry.getStatus(zookeeperRegistration)).isEqualTo("UP");
+	}
+
+	@Test
+	public void set_instance_unhealthy_and_check_service_registry() {
+		modifyableHealthContributor.setHealthy(false);
+		await().until(() -> zookeeperServiceRegistry.getStatus(zookeeperRegistration).equals("DOWN"));
+	}
+
+	@Test
+	public void set_instance_healthy_unhealthy_healthy_and_check_service_registry_after_each_change() {
+		modifyableHealthContributor.setHealthy(true);
+		await().until(() -> zookeeperServiceRegistry.getStatus(zookeeperRegistration).equals("UP"));
+		modifyableHealthContributor.setHealthy(false);
+		await().until(() -> zookeeperServiceRegistry.getStatus(zookeeperRegistration).equals("DOWN"));
+		modifyableHealthContributor.setHealthy(true);
+		await().until(() -> zookeeperServiceRegistry.getStatus(zookeeperRegistration).equals("UP"));
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@Import(CommonTestConfig.class)
+	@Profile("instancestatuspublishing")
+	@RestController
+	@EnableScheduling
+	static class Config {
+
+		@Bean
+		public ModifyableHealthContributor simpleHealthContributor() {
+			return new ModifyableHealthContributor();
+		}
+
+	}
+
+	static class ModifyableHealthContributor extends AbstractHealthIndicator {
+
+		private boolean isHealthy = true;
+
+		@Override
+		protected void doHealthCheck(Builder builder) throws Exception {
+			if (isHealthy) {
+				builder.up().build();
+			}
+			else {
+				builder.down().build();
+			}
+		}
+
+		public boolean isHealthy() {
+			return isHealthy;
+		}
+
+		public void setHealthy(boolean healthy) {
+			isHealthy = healthy;
+		}
+	}
+
+}

--- a/spring-cloud-zookeeper-discovery/src/test/resources/application-instancestatuspublishing.yml
+++ b/spring-cloud-zookeeper-discovery/src/test/resources/application-instancestatuspublishing.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: instanceStatusPublishingApp
+  cloud:
+    zookeeper:
+      discovery:
+        publishInstanceHealthStatus: true
+        instanceHealthStatusPublishInterval: 1000
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/ModifyableHealthContributer.java
+++ b/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/ModifyableHealthContributer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.zookeeper.sample;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+
+public class ModifyableHealthContributer extends AbstractHealthIndicator {
+
+	private boolean isHealthy = true;
+
+	@Override
+	protected void doHealthCheck(Builder builder) throws Exception {
+		if (isHealthy) {
+			builder.up().build();
+		}
+		else {
+			builder.down().build();
+		}
+	}
+
+	public void setHealthy(boolean healthy) {
+		isHealthy = healthy;
+	}
+}

--- a/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
+++ b/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +43,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration(proxyBeanMethods = false)
 @EnableAutoConfiguration
 @RestController
+@EnableScheduling
 @EnableFeignClients
 public class SampleZookeeperApplication {
 
@@ -59,6 +61,9 @@ public class SampleZookeeperApplication {
 
 	@Autowired
 	private AppClient appClient;
+
+	@Autowired
+	private ModifyableHealthContributer modifyableHealthContributer;
 
 	@Autowired(required = false)
 	private Registration registration;
@@ -86,6 +91,18 @@ public class SampleZookeeperApplication {
 		return this.env.getProperty(prop, "Not Found");
 	}
 
+	@RequestMapping("/up")
+	public String up() {
+		modifyableHealthContributer.setHealthy(true);
+		return "Instance is now marked as healthy.";
+	}
+
+	@RequestMapping("/down")
+	public String down() {
+		modifyableHealthContributer.setHealthy(false);
+		return "Instance is now marked as unhealthy.";
+	}
+
 	public String rt() {
 		return this.rest.getForObject("http://" + this.appName + "/hi", String.class);
 	}
@@ -94,6 +111,11 @@ public class SampleZookeeperApplication {
 	@LoadBalanced
 	RestTemplate loadBalancedRestTemplate() {
 		return new RestTemplate();
+	}
+
+	@Bean
+	ModifyableHealthContributer modifyableHealthContributer() {
+		return new ModifyableHealthContributer();
 	}
 
 	public static void main(String[] args) {


### PR DESCRIPTION
Adding support for automatic instance status publishing based on the HealthEndpoint to respect custom HealthIndicator instances. Therfore a ZookeeperInstanceHealthPublisher is introduced. Only activated when HealthEndpoint and TaskScheduler are available. fixedDelay can be configured. Fixes gh-266

The implementation is based on periodically querying the HealthEndpoint. If the status differs to the one in the service registry it is updated.

I added two endpoints to the sample app /up and /down. These set a flag inside a simple custom HealthIndicator giving the possibility to test it inside the sample app (be sure to activate automat instance status publishing via the properties).

Tests & documentation added .