### PR TITLE
refactor: Remove `@RequestMapping` annotations

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeperDiscoveryTests.java
@@ -46,8 +46,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -153,7 +152,7 @@ public class ZookeeperDiscoveryTests {
 	@FeignClient("loadBalancerApp")
 	public interface IdUsingFeignClient {
 
-		@RequestMapping(method = RequestMethod.GET, value = "/hi")
+		@GetMapping("/hi")
 		String hi();
 
 	}
@@ -172,7 +171,7 @@ public class ZookeeperDiscoveryTests {
 			return new TestLoadBalancedClient(restTemplate, springAppName);
 		}
 
-		@RequestMapping("/hi")
+		@GetMapping("/hi")
 		public String hi() {
 			return "hi";
 		}
@@ -183,7 +182,7 @@ public class ZookeeperDiscoveryTests {
 	@Profile("loadbalancer")
 	class PingController {
 
-		@RequestMapping("/ping")
+		@GetMapping("/ping")
 		String ping() {
 			return "pong";
 		}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeprDiscoveryNonWebAppTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/ZookeeprDiscoveryNonWebAppTests.java
@@ -34,7 +34,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.SocketUtils;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -119,7 +119,7 @@ public class ZookeeprDiscoveryNonWebAppTests {
 	@RestController
 	static class HelloProducer {
 
-		@RequestMapping("/")
+		@GetMapping("/")
 		public String foo() {
 			return "foo";
 		}

--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/dependency/DependencyConfig.java
@@ -29,9 +29,8 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -79,10 +78,10 @@ class PortListener implements ApplicationListener<WebServerInitializedEvent> {
 @FeignClient("someAlias")
 interface AliasUsingFeignClient {
 
-	@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
+	@GetMapping("/application/beans")
 	String getBeans();
 
-	@RequestMapping(method = RequestMethod.GET, value = "/checkHeaders")
+	@GetMapping("/checkHeaders")
 	String checkHeaders();
 
 }
@@ -90,7 +89,7 @@ interface AliasUsingFeignClient {
 @FeignClient("nameWithoutAlias")
 interface IdUsingFeignClient {
 
-	@RequestMapping(method = RequestMethod.GET, value = "/application/beans")
+	@GetMapping("/application/beans")
 	String getBeans();
 
 }
@@ -104,17 +103,17 @@ class PingController {
 		this.portListener = portListener;
 	}
 
-	@RequestMapping("/ping")
+	@GetMapping("/ping")
 	String ping() {
 		return "pong";
 	}
 
-	@RequestMapping("/port")
+	@GetMapping("/port")
 	Integer port() {
 		return this.portListener.getPort();
 	}
 
-	@RequestMapping("/checkHeaders")
+	@GetMapping("/checkHeaders")
 	String checkHeaders(@RequestHeader("Content-Type") String contentType,
 			@RequestHeader("header1") Collection<String> header1,
 			@RequestHeader("header2") Collection<String> header2) {

--- a/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
+++ b/spring-cloud-zookeeper-sample/src/main/java/org/springframework/cloud/zookeeper/sample/SampleZookeeperApplication.java
@@ -30,8 +30,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -66,22 +65,22 @@ public class SampleZookeeperApplication {
 	@Autowired
 	private RestTemplate rest;
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public ServiceInstance lb() {
 		return this.loadBalancer.choose(this.appName);
 	}
 
-	@RequestMapping("/hi")
+	@GetMapping("/hi")
 	public String hi() {
 		return "Hello World! from " + this.registration;
 	}
 
-	@RequestMapping("/self")
+	@GetMapping("/self")
 	public String self() {
 		return this.appClient.hi();
 	}
 
-	@RequestMapping("/myenv")
+	@GetMapping("/myenv")
 	public String env(@RequestParam("prop") String prop) {
 		return this.env.getProperty(prop, "Not Found");
 	}
@@ -103,7 +102,7 @@ public class SampleZookeeperApplication {
 	@FeignClient("testZookeeperApp")
 	interface AppClient {
 
-		@RequestMapping(path = "/hi", method = RequestMethod.GET)
+		@GetMapping("/hi")
 		String hi();
 
 	}


### PR DESCRIPTION
Co-authored-by: Moderne <team@moderne.io>

Hey guys! I'm too lazy to do this myself, so I've got Moderne to do it for me.

Changing to GetMapping, the preferred annotation.