### PR TITLE
Support main port not being set when using SSL.

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ServiceInstanceRegistration.java
+++ b/spring-cloud-zookeeper-discovery/src/main/java/org/springframework/cloud/zookeeper/serviceregistry/ServiceInstanceRegistration.java
@@ -84,7 +84,11 @@ public class ServiceInstanceRegistration implements ZookeeperRegistration {
 		if (this.serviceInstance == null) {
 			return 0;
 		}
-		return this.serviceInstance.getPort();
+		Integer port = this.serviceInstance.getPort();
+		if (port == null) { // might be the case with SSL enabled
+			return 0;
+		}
+		return port.intValue();
 	}
 
 	public void setPort(int port) {


### PR DESCRIPTION
When using HTTPS/SSL the 'port' may not be set from property `spring.cloud.zookeeper.discovery.instance-port`. In that case avoid throwing an exception and take the port at runtime.