### PR TITLE
Move the creation of bootstrap beans into create function

### DIFF
--- a/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerBootstrapperTests.java
+++ b/spring-cloud-zookeeper-discovery/src/test/java/org/springframework/cloud/zookeeper/discovery/configclient/ZookeeperConfigServerBootstrapperTests.java
@@ -131,7 +131,10 @@ public class ZookeeperConfigServerBootstrapperTests {
 							.get(ConfigServerInstanceProvider.Function.class);
 					assertThat(providerFn.apply("id", event.getBootstrapContext().get(Binder.class), event.getBootstrapContext().get(BindHandler.class), mock(Log.class))).as("Should return empty list.")
 							.isNotNull();
-					bootstrapDiscoveryClient.set(event.getBootstrapContext().get(ZookeeperDiscoveryClient.class));
+					bootstrapDiscoveryClient.set(((ZookeeperConfigServerBootstrapper.ZookeeperFunction) providerFn).getDiscoveryClient());
+					//Since we don't call the provider function until this close event we need to promote the discovery client
+					event.getApplicationContext().getBeanFactory().registerSingleton("zookeeperServiceDiscovery",
+							bootstrapDiscoveryClient.get());
 				})).run();
 
 		ZookeeperDiscoveryClient discoveryClient = context.getBean(ZookeeperDiscoveryClient.class);


### PR DESCRIPTION
The change I made in #317 which registered a new [`ConfigSeverInstanceProvider.Function`](https://github.com/spring-cloud/spring-cloud-zookeeper/pull/317/files#diff-f29ec6dc3150e4b110618fecac383aea6584a736cea1da36bf5c27178518971eR122) only partially worked.  All the beans that were registered in the `initialize` method really didn't do anything anymore.  They all check if the right properties are enabled but that always resulted in `false` because the properties are not set in the environment when Boot initially load configuration.  

Further more the new `ConfigServerInstanceProvider.Function` did not check if existing beans were already registered. I attempted to fix that in #325 but that fix did not work as I thought it did.

This fix should truly fix #324 