### PR TITLE
Exclude release train workflows from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
     schedule:
       interval: "weekly"
   - package-ecosystem: maven


### PR DESCRIPTION
Dependabot was proposing GitHub Actions dependency updates for release train workflows that we do not want it to manage. This change keeps those workflow files stable and avoids unnecessary update noise.

## What changed
- Added `exclude-paths` to the `github-actions` updater in `.github/dependabot.yml`
- Excluded:
  - `.github/workflows/release-train-test.yml`
  - `.github/workflows/release-train-build.yml`

## Notes
- This applies to the repository's GitHub Actions Dependabot updates and keeps existing scheduling/branch targeting unchanged.